### PR TITLE
Krisjand

### DIFF
--- a/commander3/parameter_files/defaults/components/monodipole/md_LFI.defaults
+++ b/commander3/parameter_files/defaults/components/monodipole/md_LFI.defaults
@@ -6,5 +6,5 @@ COMP_POLARIZATION&&           = .false.
 COMP_CG_SAMPLE_GROUP&&        = 0
 COMP_MD_MONO_FROM_PRIOR&&     = 0.4-Haslam
 COMP_MD_DEFINITION_FILE&&     = init_md_BP8.2_v7.dat
-COMP_INIT_FROM_HDF&&          = none default
+COMP_INIT_FROM_HDF&&          = default
 

--- a/commander3/parameter_files/defaults/components/synch/synch_LFI_localsampler.defaults
+++ b/commander3/parameter_files/defaults/components/synch/synch_LFI_localsampler.defaults
@@ -26,4 +26,4 @@ COMP_BETA_POL_NUM_PIXREG&&    = 4                              # number of pixel
 COMP_BETA_POL_FIX_PIXREG&&    = 1,3                          # pixel regions to fix, i.e. freeze on init
 COMP_BETA_POL_PIXREG_PRIORS&& = none
 COMP_BETA_PIXREG_MAP&&        = UF_sindex_4regions_n1024.fits  # Pixel region map (from 1 -> N). 'fullsky' -> all pixels = 1
-COMP_BETA_PIXREG_INITVALUE_MAP&& = init_synch_beta_noSmooth_BP8.11.fits
+COMP_BETA_PIXREG_INITVALUE_MAP&& = none 

--- a/commander3/parameter_files/param_BP9.0.txt
+++ b/commander3/parameter_files/param_BP9.0.txt
@@ -278,6 +278,7 @@ CG_SAMPLING_GROUP_MAXITER03  = 50
 @START 01
 @DEFAULT components/cmb/cmb_LFI.defaults
 COMP_INPUT_AMP_MAP&&          = init_cmb_amp_BP8.1_v1.fits
+COMP_INIT_FROM_HDF&&          = default
 @END 01
 
 
@@ -293,6 +294,7 @@ COMP_BETA_ALMSAMP_INIT&&      = init_alm_synch_beta_4reg_BP8.dat
 COMP_BETA_MASK&&              = mask_synch_beta_BP8_10deg_new_chisqmask.fits # index sampling mask for smoothed log-likelihood eval. local sampler.
 COMP_BETA_PIXREG_MAP&&        = UF_sindex_4regions_n1024.fits  # Pixel region map (from 1 -> N). 'fullsky' -> all pixels = 1
 COMP_BETA_PIXREG_INITVALUE_MAP&& = init_synch_beta_noSmooth_BP8.11.fits
+COMP_INIT_FROM_HDF&&          = default
 @END 02
 
 # Thermal dust component
@@ -306,6 +308,7 @@ COMP_INPUT_T_MAP&&            = init_dust_T_BP8.1_v1.fits
 # New Local sampling parameters, 'dust'
 COMP_BETA_ALMSAMP_INIT&&      = init_alm_dust_beta.dat
 COMP_BETA_MASK&&              = mask_dust_beta_BP8_10deg.fits  # index sampling mask for smoothed log-likelihood eval. local sampler.
+COMP_INIT_FROM_HDF&&          = default
 @END 03
 
 # Mono- and dipole component
@@ -313,6 +316,7 @@ COMP_BETA_MASK&&              = mask_dust_beta_BP8_10deg.fits  # index sampling 
 @DEFAULT components/monodipole/md_LFI.defaults
 COMP_MD_MONO_FROM_PRIOR&&     = 0.4-Haslam
 COMP_MD_DEFINITION_FILE&&     = init_md_BP8.2_v7.dat 
+COMP_INIT_FROM_HDF&&          = default
 @END 04
 
 # Radio sources
@@ -321,6 +325,7 @@ COMP_MD_DEFINITION_FILE&&     = init_md_BP8.2_v7.dat
 COMP_CATALOG&&                 = COM_AT20G_GB6_NVSS_PCCS2_nothreshold_v8.dat
 COMP_INIT_CATALOG&&            = init_radio_BP8.11.dat
 COMP_PTSRC_TEMPLATE&&          = COM_AT20G_GB6_NVSS_PCCS2_nothreshold_v39.h5
+COMP_INIT_FROM_HDF&&          = default
 @END 05
 
 # freefree component ---------------------------------------------------------------------
@@ -331,6 +336,7 @@ COMP_INPUT_AMP_MAP&&          = init_ff_amp_BP8.1_v1.fits
 COMP_PRIOR_AMP_MAP&&          = ff_prior_mean_2015_median_90arc.fits none
 # New Local sampling parameters. 'freefree, ff'
 @DEFAULT components/freefree/freefree_LFI_localsampler.defaults
+COMP_INIT_FROM_HDF&&          = default
 @END 06
 
 # Low-frequency AME component ------------------------------------------------------------------
@@ -346,9 +352,11 @@ COMP_PRIOR_AMP_MAP&&          = ame_prior_mean_857_scaled2.40.fits
 # New Local sampling parameters, 'ame'
 COMP_NU_P_MASK&&              = mask_AME_nu_p_BP8_10deg_new_chisqmask.fits   # index sampling mask for smoothed log-likelihood eval. local sampler.
 COMP_ALPHA_MASK&&              = mask_AME_nu_p_BP8_10deg.fits mask_AME_n1024_v3.fits  # index sampling mask for smoothed log-likelihood eval. local sampler.
+COMP_INIT_FROM_HDF&&          = default
 @END 07
 
 # CMB relativistic quadrupole correction
 @START 08
 @DEFAULT components/cmb/cmb_relquad.defaults
+COMP_INIT_FROM_HDF&&          = none
 @END 08

--- a/commander3/src/comm_Cl_mod.f90
+++ b/commander3/src/comm_Cl_mod.f90
@@ -1295,6 +1295,9 @@ contains
     case ('exp')
        call write_Dl_to_FITS(self, 'c'//ctext//'_k'//itext)
        call write_powlaw_to_FITS(self, 'c'//ctext, hdffile=hdffile, hdfpath=hdfpath)
+    case ('gauss')
+       call write_Dl_to_FITS(self, 'c'//ctext//'_k'//itext)
+       call write_powlaw_to_FITS(self, 'c'//ctext, hdffile=hdffile, hdfpath=hdfpath)
     end select
 
   end subroutine writeFITS
@@ -1391,7 +1394,7 @@ contains
     if (present(hdffile)) then
        call write_hdf(hdffile, trim(adjustl(hdfpath))//'/Dl_amp',  self%amp)
        call write_hdf(hdffile, trim(adjustl(hdfpath))//'/Dl_beta', self%beta)
-       call write_hdf(hdffile, trim(adjustl(hdfpath))//'/Dl_theta', self%theta)
+       if (trim(self%type)=='power_law_gauss') call write_hdf(hdffile, trim(adjustl(hdfpath))//'/Dl_theta', self%theta)
     end if
     
   end subroutine write_powlaw_to_FITS
@@ -1422,6 +1425,10 @@ contains
        call read_hdf(hdffile, trim(adjustl(hdfpath))//'/Dl_amp',  self%amp)
        call read_hdf(hdffile, trim(adjustl(hdfpath))//'/Dl_beta', self%beta)
        call self%updateExponential()
+    case ('gauss')
+       call read_hdf(hdffile, trim(adjustl(hdfpath))//'/Dl_amp',  self%amp)
+       call read_hdf(hdffile, trim(adjustl(hdfpath))//'/Dl_beta', self%beta)
+       call self%updateGaussian()
     end select
     call self%updateS()
 

--- a/commander3/src/comm_N_QUcov_mod.f90
+++ b/commander3/src/comm_N_QUcov_mod.f90
@@ -75,7 +75,7 @@ contains
     dir = trim(cpar%datadir) // '/'
 
     ! Component specific parameters
-    constructor%type              = cpar%ds_noise_format(id_abs)
+    constructor%type              = trim(cpar%ds_noise_format(id_abs))
     constructor%nmaps             = 3
     constructor%pol               = .true.
     constructor%uni_fsky          = 1.d0 

--- a/commander3/src/comm_param_mod.f90
+++ b/commander3/src/comm_param_mod.f90
@@ -203,6 +203,7 @@ module comm_param_mod
      real(dp),           allocatable, dimension(:,:)   :: cs_cl_prior
      real(dp),           allocatable, dimension(:,:)   :: cs_cl_amp_def
      real(dp),           allocatable, dimension(:,:)   :: cs_cl_beta_def
+     real(dp),           allocatable, dimension(:,:)   :: cs_cl_theta_def
      integer(i4b),       allocatable, dimension(:)     :: cs_cl_poltype
      logical(lgt),       allocatable, dimension(:)     :: cs_output_EB
      character(len=512), allocatable, dimension(:)     :: cs_input_amp
@@ -673,7 +674,7 @@ contains
     allocate(cpar%cs_lpivot(n), cpar%cs_mask(n), cpar%cs_mono_prior(n), cpar%cs_fwhm(n), cpar%cs_poltype(MAXPAR,n))
     allocate(cpar%cs_latmask(n), cpar%cs_defmask(n), cpar%cs_cg_samp_group_maxiter(n))
     allocate(cpar%cs_indmask(n), cpar%cs_amp_rms_scale(n))
-    allocate(cpar%cs_cl_amp_def(n,3), cpar%cs_cl_beta_def(n,3), cpar%cs_cl_prior(n,2))
+    allocate(cpar%cs_cl_amp_def(n,3), cpar%cs_cl_beta_def(n,3), cpar%cs_cl_theta_def(n,3), cpar%cs_cl_prior(n,2))
     allocate(cpar%cs_input_amp(n), cpar%cs_prior_amp(n), cpar%cs_input_ind(MAXPAR,n))
     allocate(cpar%cs_theta_def(MAXPAR,n), cpar%cs_p_uni(n,2,MAXPAR), cpar%cs_p_gauss(n,2,MAXPAR))
     allocate(cpar%cs_catalog(n), cpar%cs_init_catalog(n), cpar%cs_SED_template(4,n), cpar%cs_cg_scale(3,n))
@@ -753,6 +754,10 @@ contains
                   & par_dp=cpar%cs_cl_amp_def(i,1))
              call get_parameter_hashtable(htbl, 'COMP_CL_DEFAULT_BETA_T'//itext, len_itext=len_itext, &
                   & par_dp=cpar%cs_cl_beta_def(i,1))
+             if (trim(cpar%cs_cltype(i))=='power_law_gauss') then
+                call get_parameter_hashtable(htbl, 'COMP_CL_DEFAULT_THETA_T'//itext, len_itext=len_itext, &
+                     & par_dp=cpar%cs_cl_theta_def(i,1))
+             end if
              if (cpar%cs_polarization(i)) then
                 call get_parameter_hashtable(htbl, 'COMP_CL_DEFAULT_AMP_E'//itext, len_itext=len_itext, &
                      & par_dp=cpar%cs_cl_amp_def(i,2))
@@ -762,6 +767,12 @@ contains
                      & par_dp=cpar%cs_cl_amp_def(i,3))
                 call get_parameter_hashtable(htbl, 'COMP_CL_DEFAULT_BETA_B'//itext, len_itext=len_itext, &  
                 & par_dp=cpar%cs_cl_beta_def(i,3))
+                if (trim(cpar%cs_cltype(i))=='power_law_gauss') then
+                   call get_parameter_hashtable(htbl, 'COMP_CL_DEFAULT_THETA_E'//itext, len_itext=len_itext, &
+                     & par_dp=cpar%cs_cl_theta_def(i,2))
+                   call get_parameter_hashtable(htbl, 'COMP_CL_DEFAULT_THETA_B'//itext, len_itext=len_itext, &
+                        & par_dp=cpar%cs_cl_theta_def(i,3))
+                end if
              end if
              cpar%cs_cl_amp_def(i,:) = cpar%cs_cl_amp_def(i,:) / cpar%cs_cg_scale(:,i)**2
           end if

--- a/commander3/src/comm_param_mod.f90
+++ b/commander3/src/comm_param_mod.f90
@@ -1,5 +1,5 @@
 !================================================================================
-!
+! 
 ! Copyright (C) 2020 Institute of Theoretical Astrophysics, University of Oslo.
 !
 ! This file is part of Commander3.

--- a/commander3/src/commander.f90
+++ b/commander3/src/commander.f90
@@ -224,7 +224,7 @@ program commander
      !----------------------------------------------------------------------------------
      ! Process TOD structures
 
-     if (iter > 0 .and. cpar%enable_TOD_analysis .and. (iter <= 2 .or. mod(iter,cpar%tod_freq) == 0)) then
+     if (iter > 1 .and. cpar%enable_TOD_analysis .and. (iter <= 2 .or. mod(iter,cpar%tod_freq) == 0)) then
         call process_TOD(cpar, cpar%mychain, iter, handle)
      end if
 


### PR DESCRIPTION
I've added a theta parameter to the 'power_law_gauss' type of the Cl-prior. This theta parameter works like the existing beta parameter for the 'gauss' Cl-prior type. This way the 'power_law_gauss' type actually becomes a product of the 'power_law' and 'gauss' type Cl-priors.

There are a few additions and changes to the writing/reading routines to HDF/fits, also for the other Cl-prior types (like 'gauss').

The new parameter is COMP_CL_DEFAULT_THETA_{T,E,B}&& = real dp ( >= 0 ), only valid (and looked for) if COMP_CL_TYPE&& = 'power_law_gauss'

The default parameter files have been updated accordingly. In addition I've added the COMP_INIT_FOR_HDF&& parameter to the main parameter file as this is switched on/off on a more regular basis

Finally, in commander.f90, line 227 have been changed so that the TOD sampling first happen on sample 2 (same as spectral parameters). This is to ensure that if a component is not initialized from chain, then Commander samples the components first. The users that only initialize from chain is free to change this, but I think that sampling TOD from sample 2 should be the default.