### PR TITLE
Major rewrite of LFI mod, now using comm_tod_driver_mod

### DIFF
--- a/commander3/config/config.ita_internal
+++ b/commander3/config/config.ita_internal
@@ -49,11 +49,11 @@ export MPCC := mpiicc
 
 # =========== Compiler Optimizations =============
 #main
-export F90FLAGS := -fpe0 -march=native -g -O2 -traceback -assume byterecl -heap-arrays 16384 -qopenmp -parallel -lmkl 
+#export F90FLAGS := -fpe0 -march=native -g -O2 -traceback -assume byterecl -heap-arrays 16384 -qopenmp -parallel -lmkl 
 
 #debug
 #
-#export F90FLAGS := -fpe0 -march=native -g -C -traceback -assume byterecl -heap-arrays 16384 -qopenmp -parallel -lmkl -fpe0
+export F90FLAGS := -fpe0 -march=native -g -C -traceback -assume byterecl -heap-arrays 16384 -qopenmp -parallel -lmkl -fpe0
 
 
 #export F90FLAGS := -fpe0 -march=native -O2 -CB -g -traceback -assume byterecl -heap-arrays 16384 -qopenmp -parallel -lmkl 

--- a/commander3/config/config.ita_internal
+++ b/commander3/config/config.ita_internal
@@ -49,14 +49,15 @@ export MPCC := mpiicc
 
 # =========== Compiler Optimizations =============
 #main
-#export F90FLAGS := -fpe0 -march=native -g -O2 -traceback -assume byterecl -heap-arrays 16384 -qopenmp -parallel -lmkl 
+#
+export F90FLAGS := -fpe0 -march=native -g -O2 -traceback -assume byterecl -heap-arrays 16384 -qopenmp -parallel -lmkl 
 
 #debug
 #
-export F90FLAGS := -fpe0 -march=native -g -C -traceback -assume byterecl -heap-arrays 16384 -qopenmp -parallel -lmkl -fpe0
+#export F90FLAGS := -fpe0 -march=native -g -C -traceback -assume byterecl -heap-arrays 16384 -qopenmp -parallel -lmkl -fpe0
 
 
-#export F90FLAGS := -fpe0 -march=native -O2 -CB -g -traceback -assume byterecl -heap-arrays 16384 -qopenmp -parallel -lmkl 
+#export F90FLAGS := -fpe0 -march=native -C -g -check noarg_temp_created -traceback -assume byterecl -heap-arrays 16384 -qopenmp -parallel -lmkl 
 #export F90FLAGS := -check bounds -CB -check format -check pointers -check uninit -check output_conversion -assume byterecl -traceback -heap-arrays 16384 -fpe0 -O0 -g -traceback -assume byterecl -heap-arrays 16384 -qopenmp
 #export F90FLAGS := -check all -O0 -g -traceback -assume byterecl -heap-arrays 16384 -qopenmp -ftrapuv -debug all -diag-disable 406
 

--- a/commander3/src/Makefile
+++ b/commander3/src/Makefile
@@ -47,12 +47,12 @@ comm_conviqt_mod.o :       sharp.o comm_map_mod.o comm_shared_arr_mod.o
 comm_hdf_mod.o :           comm_utils.o
 comm_fft_mod.o :           locate_mod.o comm_utils.o comm_param_mod.o
 comm_tod_mod.o :           comm_utils.o comm_fft_mod.o comm_map_mod.o comm_hdf_mod.o comm_param_mod.o \
-			   comm_huffman_mod.o comm_zodi_mod.o
+			   comm_huffman_mod.o comm_zodi_mod.o comm_tod_orbdipole_mod.o
 comm_tod_mapmaking_mod.o:  comm_tod_mod.o
 comm_tod_bandpass_mod.o:   comm_tod_mod.o
 comm_tod_noise_mod.o:      comm_tod_mod.o comm_tod_jump_mod.o InvSamp_mod.o
 comm_tod_gain_mod.o:       comm_tod_mod.o comm_tod_noise_mod.o
-comm_tod_orbdipole_mod.o:  comm_map_mod.o comm_tod_mod.o
+comm_tod_orbdipole_mod.o:  comm_map_mod.o comm_utils.o
 comm_tod_pointing_mod.o:   comm_tod_mod.o
 comm_utils.o :             comm_defs.o spline_1D_mod.o
 comm_shared_arr_mod.o :    comm_utils.o
@@ -125,7 +125,7 @@ comm_tod_jump_mod.o :      comm_utils.o sort_utils.o
 comm_tod_WMAP_mod.o :      comm_tod_mod.o comm_shared_arr_mod.o comm_conviqt_mod.o comm_4D_map_mod.o comm_zodi_mod.o \
                            comm_tod_mapmaking_mod.o comm_tod_bandpass_mod.o comm_tod_pointing_mod.o \
 			   comm_tod_orbdipole_mod.o comm_tod_gain_mod.o comm_tod_noise_mod.o
-comm_tod_simulations_mod.o: comm_tod_LFI_mod.o comm_hdf_mod.o comm_fft_mod.o comm_shared_arr_mod.o \
+comm_tod_simulations_mod.o: comm_hdf_mod.o comm_fft_mod.o comm_shared_arr_mod.o \
 														spline_1D_mod.o comm_param_mod.o comm_utils.o
 
 commander.o :              comm_signal_mod.o comm_data_mod.o comm_cr_mod.o comm_chisq_mod.o \

--- a/commander3/src/Makefile
+++ b/commander3/src/Makefile
@@ -32,7 +32,7 @@ COBJS  := d1mach.o drc3jj.o hashtbl.o hashtbl_4Dmap.o powell_mod.o comm_hdf_mod.
           comm_B_mod.o comm_B_bl_mod.o comm_beam_mod.o \
           comm_F_int_mod.o comm_F_int_1D_mod.o comm_F_int_0D_mod.o comm_F_int_2D_mod.o \
           comm_fft_mod.o comm_tod_mod.o comm_tod_mapmaking_mod.o comm_tod_bandpass_mod.o comm_tod_gain_mod.o comm_tod_pointing_mod.o comm_tod_LFI_mod.o comm_tod_jump_mod.o comm_tod_SPIDER_mod.o comm_tod_orbdipole_mod.o \
-          comm_tod_noise_mod.o comm_F_line_mod.o comm_data_mod.o comm_bp_mod.o comm_Cl_mod.o \
+          comm_tod_noise_mod.o comm_tod_driver_mod.o comm_F_line_mod.o comm_data_mod.o comm_bp_mod.o comm_Cl_mod.o \
           comm_chisq_mod.o comm_cr_mod.o comm_signal_mod.o comm_output_mod.o comm_tod_WMAP_mod.o \
 					comm_tod_simulations_mod.o
 
@@ -111,8 +111,13 @@ comm_chisq_mod.o :         comm_data_mod.o comm_comp_mod.o
 comm_output_mod.o :        comm_comp_mod.o comm_hdf_mod.o comm_Cl_mod.o
 comm_4D_map_mod.o :        hashtbl_4Dmap.o comm_hdf_mod.o comm_utils.o
 comm_zodi_mod.o :          comm_utils.o comm_param_mod.o comm_bp_utils.o
-comm_tod_LFI_mod.o :       comm_tod_mod.o comm_shared_arr_mod.o comm_conviqt_mod.o comm_4D_map_mod.o comm_zodi_mod.o \
-                           comm_tod_mapmaking_mod.o comm_tod_bandpass_mod.o comm_tod_pointing_mod.o comm_tod_orbdipole_mod.o comm_tod_gain_mod.o comm_tod_noise_mod.o
+comm_tod_driver_mod.o :    comm_tod_mod.o comm_zodi_mod.o \
+                           comm_tod_mapmaking_mod.o comm_tod_bandpass_mod.o \
+                           comm_tod_pointing_mod.o comm_tod_orbdipole_mod.o \
+                           comm_tod_gain_mod.o comm_tod_noise_mod.o \
+                           comm_tod_simulations_mod.o comm_shared_arr_mod.o 
+comm_tod_LFI_mod.o :       comm_tod_driver_mod.o comm_shared_arr_mod.o \
+                           comm_conviqt_mod.o comm_4D_map_mod.o 
 comm_tod_SPIDER_mod.o :    comm_tod_mod.o comm_shared_arr_mod.o comm_conviqt_mod.o comm_4D_map_mod.o comm_zodi_mod.o \
                            comm_tod_mapmaking_mod.o comm_tod_bandpass_mod.o comm_tod_pointing_mod.o comm_tod_orbdipole_mod.o comm_tod_gain_mod.o comm_tod_noise_mod.o \
                            comm_tod_jump_mod.o 

--- a/commander3/src/comm_conviqt_mod.f90
+++ b/commander3/src/comm_conviqt_mod.f90
@@ -197,6 +197,7 @@ contains
     ! y = (y_0 (x_1 - x) + y_1 (x - x_0))/(x_1 - x_0)
     x0     = psii * self%psires
     x1     = psiu * self%psires
+    !write(*,*) psii+1, psiu+1, self%psisteps
     interp = (self%c%a(pixnum+1, psii+1) * (x1 - unwrap) + &
          & self%c%a(pixnum+1, psiu+1) * (unwrap - x0))/(x1 - x0)
 

--- a/commander3/src/comm_defs.f90
+++ b/commander3/src/comm_defs.f90
@@ -30,6 +30,7 @@ module comm_defs
   real(dp), parameter :: c         = 2.99792458d8
   real(dp)            :: T_CMB     = 2.72548d0
   real(dp)            :: T_CMB_DIP = 3359.5d-6
+  real(dp)            :: v_solar(3)= [0.d0, 0.d0, 0.d0]
 
   !**************************************************
   !               Counters

--- a/commander3/src/comm_hdf_mod.f90
+++ b/commander3/src/comm_hdf_mod.f90
@@ -373,6 +373,16 @@ contains
     call get_size_hdf(file, setname, ext)
     allocate(buffer(ext(1),ext(2)))
     ext2 = ext
+    ! Validate that sizes are consistent
+    !call get_size_hdf(file, setname, ext)
+    if (any(ext /= s)) then
+       write(*,*) 'HDF error -- inconsistent array sizes'
+       write(*,*) '             Filename       = ', trim(file%filename)
+       write(*,*) '             Setname        = ', trim(setname)
+       write(*,*) '             HDF size       = ', ext
+       write(*,*) '             Requested size = ', int(s,i4b)
+       !write(*,*) opt_, 'Optional parameter'
+    end if
     call h5dread_f(file%sethandle, H5T_NATIVE_DOUBLE, buffer, ext2, file%status)
     val = buffer(1:s(1),1:s(2))
     deallocate(buffer)
@@ -400,6 +410,16 @@ contains
     call get_size_hdf(file, setname, ext)
     allocate(buffer(ext(1),ext(2)))
     ext2 = ext
+    ! Validate that sizes are consistent
+    !call get_size_hdf(file, setname, ext)
+    if (any(ext /= s)) then
+       write(*,*) 'HDF error -- inconsistent array sizes'
+       write(*,*) '             Filename       = ', trim(file%filename)
+       write(*,*) '             Setname        = ', trim(setname)
+       write(*,*) '             HDF size       = ', ext
+       write(*,*) '             Requested size = ', int(s,i4b)
+       !write(*,*) opt_, 'Optional parameter'
+    end if
     call h5dread_f(file%sethandle, H5T_NATIVE_INTEGER, buffer, ext2, file%status)
     val = buffer(1:s(1),1:s(2))
     deallocate(buffer)
@@ -434,8 +454,8 @@ contains
     end if
     call open_hdf_set(file, setname)
     s = int(shape(val))
-    call get_size_hdf(file, setname, ext)
     ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
     if (any(ext /= s)) then
        write(*,*) 'HDF error -- inconsistent array sizes'
        write(*,*) '             Filename       = ', trim(file%filename)
@@ -476,8 +496,8 @@ contains
     end if
     call open_hdf_set(file, setname)
     s = int(shape(val))
-    call get_size_hdf(file, setname, ext)
     ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
     if (any(ext /= s)) then
        write(*,*) 'HDF error -- inconsistent array sizes'
        write(*,*) '             Filename       = ', trim(file%filename)
@@ -518,8 +538,8 @@ contains
     end if
     call open_hdf_set(file, setname)
     s = int(shape(val))
-    call get_size_hdf(file, setname, ext)
     ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
     if (any(ext /= s)) then
        write(*,*) 'HDF error -- inconsistent array sizes'
        write(*,*) '             Filename       = ', trim(file%filename)
@@ -560,8 +580,8 @@ contains
     end if
     call open_hdf_set(file, setname)
     s = int(shape(val))
-    call get_size_hdf(file, setname, ext)
     ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
     if (any(ext /= s)) then
        write(*,*) 'HDF error -- inconsistent array sizes'
        write(*,*) '             Filename       = ', trim(file%filename)
@@ -602,8 +622,8 @@ contains
     end if
     call open_hdf_set(file, setname)
     s = int(shape(val))
-    call get_size_hdf(file, setname, ext)
     ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
     if (any(ext /= s)) then
        write(*,*) 'HDF error -- inconsistent array sizes'
        write(*,*) '             Filename       = ', trim(file%filename)
@@ -644,8 +664,8 @@ contains
     end if
     call open_hdf_set(file, setname)
     s = int(shape(val))
-    call get_size_hdf(file, setname, ext)
     ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
     if (any(ext /= s)) then
        write(*,*) 'HDF error -- inconsistent array sizes'
        write(*,*) '             Filename       = ', trim(file%filename)
@@ -686,8 +706,8 @@ contains
     end if
     call open_hdf_set(file, setname)
     s = int(shape(val))
-    call get_size_hdf(file, setname, ext)
     ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
     if (any(ext /= s)) then
        write(*,*) 'HDF error -- inconsistent array sizes'
        write(*,*) '             Filename       = ', trim(file%filename)
@@ -728,8 +748,8 @@ contains
     end if
     call open_hdf_set(file, setname)
     s = int(shape(val))
-    call get_size_hdf(file, setname, ext)
     ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
     if (any(ext /= s)) then
        write(*,*) 'HDF error -- inconsistent array sizes'
        write(*,*) '             Filename       = ', trim(file%filename)
@@ -770,8 +790,8 @@ contains
     end if
     call open_hdf_set(file, setname)
     s = int(shape(val))
-    call get_size_hdf(file, setname, ext)
     ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
     if (any(ext /= s)) then
        write(*,*) 'HDF error -- inconsistent array sizes'
        write(*,*) '             Filename       = ', trim(file%filename)
@@ -812,8 +832,8 @@ contains
     end if
     call open_hdf_set(file, setname)
     s = int(shape(val))
-    call get_size_hdf(file, setname, ext)
     ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
     if (any(ext /= s)) then
        write(*,*) 'HDF error -- inconsistent array sizes'
        write(*,*) '             Filename       = ', trim(file%filename)
@@ -854,8 +874,8 @@ contains
     end if
     call open_hdf_set(file, setname)
     s = int(shape(val))
-    call get_size_hdf(file, setname, ext)
     ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
     if (any(ext /= s)) then
        write(*,*) 'HDF error -- inconsistent array sizes'
        write(*,*) '             Filename       = ', trim(file%filename)
@@ -896,8 +916,8 @@ contains
     end if
     call open_hdf_set(file, setname)
     s = int(shape(val))
-    call get_size_hdf(file, setname, ext)
     ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
     if (any(ext /= s)) then
        write(*,*) 'HDF error -- inconsistent array sizes'
        write(*,*) '             Filename       = ', trim(file%filename)
@@ -938,8 +958,8 @@ contains
     end if
     call open_hdf_set(file, setname)
     s = int(shape(val))
-    call get_size_hdf(file, setname, ext)
     ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
     if (any(ext /= s)) then
        write(*,*) 'HDF error -- inconsistent array sizes'
        write(*,*) '             Filename       = ', trim(file%filename)
@@ -980,8 +1000,8 @@ contains
     end if
     call open_hdf_set(file, setname)
     s = int(shape(val))
-    call get_size_hdf(file, setname, ext)
     ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
     if (any(ext /= s)) then
        write(*,*) 'HDF error -- inconsistent array sizes'
        write(*,*) '             Filename       = ', trim(file%filename)
@@ -1022,8 +1042,8 @@ contains
     end if
     call open_hdf_set(file, setname)
     s = int(shape(val))
-    call get_size_hdf(file, setname, ext)
     ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
     if (any(ext /= s)) then
        write(*,*) 'HDF error -- inconsistent array sizes'
        write(*,*) '             Filename       = ', trim(file%filename)
@@ -1064,8 +1084,8 @@ contains
     end if
     call open_hdf_set(file, setname)
     s = int(shape(val))
-    call get_size_hdf(file, setname, ext)
     ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
     if (any(ext /= s)) then
        write(*,*) 'HDF error -- inconsistent array sizes'
        write(*,*) '             Filename       = ', trim(file%filename)
@@ -1106,8 +1126,8 @@ contains
     end if
     call open_hdf_set(file, setname)
     s = int(shape(val))
-    call get_size_hdf(file, setname, ext)
     ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
     if (any(ext /= s)) then
        write(*,*) 'HDF error -- inconsistent array sizes'
        write(*,*) '             Filename       = ', trim(file%filename)
@@ -1148,8 +1168,8 @@ contains
     end if
     call open_hdf_set(file, setname)
     s = int(shape(val))
-    call get_size_hdf(file, setname, ext)
     ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
     if (any(ext /= s)) then
        write(*,*) 'HDF error -- inconsistent array sizes'
        write(*,*) '             Filename       = ', trim(file%filename)
@@ -1190,8 +1210,8 @@ contains
     end if
     call open_hdf_set(file, setname)
     s = int(shape(val))
-    call get_size_hdf(file, setname, ext)
     ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
     if (any(ext /= s)) then
        write(*,*) 'HDF error -- inconsistent array sizes'
        write(*,*) '             Filename       = ', trim(file%filename)
@@ -1232,8 +1252,8 @@ contains
     end if
     call open_hdf_set(file, setname)
     s = int(shape(val))
-    call get_size_hdf(file, setname, ext)
     ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
     if (any(ext /= s)) then
        write(*,*) 'HDF error -- inconsistent array sizes'
        write(*,*) '             Filename       = ', trim(file%filename)
@@ -1274,8 +1294,8 @@ contains
     end if
     call open_hdf_set(file, setname)
     s = int(shape(val))
-    call get_size_hdf(file, setname, ext)
     ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
     if (any(ext /= s)) then
        write(*,*) 'HDF error -- inconsistent array sizes'
        write(*,*) '             Filename       = ', trim(file%filename)
@@ -1316,8 +1336,8 @@ contains
     end if
     call open_hdf_set(file, setname)
     s = int(shape(val))
-    call get_size_hdf(file, setname, ext)
     ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
     if (any(ext /= s)) then
        write(*,*) 'HDF error -- inconsistent array sizes'
        write(*,*) '             Filename       = ', trim(file%filename)
@@ -1358,8 +1378,8 @@ contains
     end if
     call open_hdf_set(file, setname)
     s = int(shape(val))
-    call get_size_hdf(file, setname, ext)
     ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
     if (any(ext /= s)) then
        write(*,*) 'HDF error -- inconsistent array sizes'
        write(*,*) '             Filename       = ', trim(file%filename)
@@ -1400,8 +1420,8 @@ contains
     end if
     call open_hdf_set(file, setname)
     s = int(shape(val))
-    call get_size_hdf(file, setname, ext)
     ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
     if (any(ext /= s)) then
        write(*,*) 'HDF error -- inconsistent array sizes'
        write(*,*) '             Filename       = ', trim(file%filename)
@@ -1442,8 +1462,8 @@ contains
     end if
     call open_hdf_set(file, setname)
     s = int(shape(val))
-    call get_size_hdf(file, setname, ext)
     ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
     if (any(ext /= s)) then
        write(*,*) 'HDF error -- inconsistent array sizes'
        write(*,*) '             Filename       = ', trim(file%filename)
@@ -1484,8 +1504,8 @@ contains
     end if
     call open_hdf_set(file, setname)
     s = int(shape(val))
-    call get_size_hdf(file, setname, ext)
     ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
     if (any(ext /= s)) then
        write(*,*) 'HDF error -- inconsistent array sizes'
        write(*,*) '             Filename       = ', trim(file%filename)
@@ -1526,8 +1546,8 @@ contains
     end if
     call open_hdf_set(file, setname)
     s = int(shape(val))
-    call get_size_hdf(file, setname, ext)
     ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
     if (any(ext /= s)) then
        write(*,*) 'HDF error -- inconsistent array sizes'
        write(*,*) '             Filename       = ', trim(file%filename)
@@ -1568,8 +1588,8 @@ contains
     end if
     call open_hdf_set(file, setname)
     s = int(shape(val))
-    call get_size_hdf(file, setname, ext)
     ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
     if (any(ext /= s)) then
        write(*,*) 'HDF error -- inconsistent array sizes'
        write(*,*) '             Filename       = ', trim(file%filename)
@@ -1610,8 +1630,8 @@ contains
     end if
     call open_hdf_set(file, setname)
     s = int(shape(val))
-    call get_size_hdf(file, setname, ext)
     ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
     if (any(ext /= s)) then
        write(*,*) 'HDF error -- inconsistent array sizes'
        write(*,*) '             Filename       = ', trim(file%filename)
@@ -1652,8 +1672,8 @@ contains
     end if
     call open_hdf_set(file, setname)
     s = int(shape(val))
-    call get_size_hdf(file, setname, ext)
     ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
     if (any(ext /= s)) then
        write(*,*) 'HDF error -- inconsistent array sizes'
        write(*,*) '             Filename       = ', trim(file%filename)
@@ -1694,8 +1714,8 @@ contains
     end if
     call open_hdf_set(file, setname)
     s = int(shape(val))
-    call get_size_hdf(file, setname, ext)
     ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
     if (any(ext /= s)) then
        write(*,*) 'HDF error -- inconsistent array sizes'
        write(*,*) '             Filename       = ', trim(file%filename)
@@ -1736,8 +1756,8 @@ contains
     end if
     call open_hdf_set(file, setname)
     s = int(shape(val))
-    call get_size_hdf(file, setname, ext)
     ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
     if (any(ext /= s)) then
        write(*,*) 'HDF error -- inconsistent array sizes'
        write(*,*) '             Filename       = ', trim(file%filename)
@@ -1757,11 +1777,22 @@ contains
     real(dp) ,dimension(:), allocatable, intent(out) :: val
     integer(i4b) :: n(1)
     integer(hsize_t) :: s(1)
+    integer(i4b)     :: ext(1)
     if(allocated(val)) deallocate(val)
     call get_size_hdf(file, setname, n)
     allocate(val(n(1)))
     call open_hdf_set(file, setname)
     s = int(shape(val))
+    ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
+    if (any(ext /= s)) then
+       write(*,*) 'HDF error -- inconsistent array sizes'
+       write(*,*) '             Filename       = ', trim(file%filename)
+       write(*,*) '             Setname        = ', trim(setname)
+       write(*,*) '             HDF size       = ', ext
+       write(*,*) '             Requested size = ', int(s,i4b)
+       !write(*,*) opt_, 'Optional parameter'
+    end if
     call h5dread_f(file%sethandle, H5T_NATIVE_DOUBLE, val, s, file%status)
     call assert(file%status>=0, "comm_hdf_mod: Cannot read data from hdf set " // setname)
   end subroutine
@@ -1773,11 +1804,22 @@ contains
     real(sp) ,dimension(:), allocatable, intent(out) :: val
     integer(i4b) :: n(1)
     integer(hsize_t) :: s(1)
+    integer(i4b)     :: ext(1)
     if(allocated(val)) deallocate(val)
     call get_size_hdf(file, setname, n)
     allocate(val(n(1)))
     call open_hdf_set(file, setname)
     s = int(shape(val))
+    ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
+    if (any(ext /= s)) then
+       write(*,*) 'HDF error -- inconsistent array sizes'
+       write(*,*) '             Filename       = ', trim(file%filename)
+       write(*,*) '             Setname        = ', trim(setname)
+       write(*,*) '             HDF size       = ', ext
+       write(*,*) '             Requested size = ', int(s,i4b)
+       !write(*,*) opt_, 'Optional parameter'
+    end if
     call h5dread_f(file%sethandle, H5T_NATIVE_REAL, val, s, file%status)
     call assert(file%status>=0, "comm_hdf_mod: Cannot read data from hdf set " // setname)
   end subroutine
@@ -1789,11 +1831,22 @@ contains
     integer(i4b) ,dimension(:), allocatable, intent(out) :: val
     integer(i4b) :: n(1)
     integer(hsize_t) :: s(1)
+    integer(i4b)     :: ext(1)
     if(allocated(val)) deallocate(val)
     call get_size_hdf(file, setname, n)
     allocate(val(n(1)))
     call open_hdf_set(file, setname)
     s = int(shape(val))
+    ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
+    if (any(ext /= s)) then
+       write(*,*) 'HDF error -- inconsistent array sizes'
+       write(*,*) '             Filename       = ', trim(file%filename)
+       write(*,*) '             Setname        = ', trim(setname)
+       write(*,*) '             HDF size       = ', ext
+       write(*,*) '             Requested size = ', int(s,i4b)
+       !write(*,*) opt_, 'Optional parameter'
+    end if
     call h5dread_f(file%sethandle, H5T_NATIVE_INTEGER, val, s, file%status)
     call assert(file%status>=0, "comm_hdf_mod: Cannot read data from hdf set " // setname)
   end subroutine
@@ -1805,11 +1858,22 @@ contains
     character(len=*) ,dimension(:), allocatable, intent(out) :: val
     integer(i4b) :: n(1)
     integer(hsize_t) :: s(1)
+    integer(i4b)     :: ext(1)
     if(allocated(val)) deallocate(val)
     call get_size_hdf(file, setname, n)
     allocate(val(n(1)))
     call open_hdf_set(file, setname)
     s = int(shape(val))
+    ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
+    if (any(ext /= s)) then
+       write(*,*) 'HDF error -- inconsistent array sizes'
+       write(*,*) '             Filename       = ', trim(file%filename)
+       write(*,*) '             Setname        = ', trim(setname)
+       write(*,*) '             HDF size       = ', ext
+       write(*,*) '             Requested size = ', int(s,i4b)
+       !write(*,*) opt_, 'Optional parameter'
+    end if
     call h5dread_f(file%sethandle, H5T_NATIVE_CHARACTER, val, s, file%status)
     call assert(file%status>=0, "comm_hdf_mod: Cannot read data from hdf set " // setname)
   end subroutine
@@ -1821,11 +1885,22 @@ contains
     real(dp) ,dimension(:,:), allocatable, intent(out) :: val
     integer(i4b) :: n(2)
     integer(hsize_t) :: s(2)
+    integer(i4b)     :: ext(2)
     if(allocated(val)) deallocate(val)
     call get_size_hdf(file, setname, n)
     allocate(val(n(1),n(2)))
     call open_hdf_set(file, setname)
     s = int(shape(val))
+    ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
+    if (any(ext /= s)) then
+       write(*,*) 'HDF error -- inconsistent array sizes'
+       write(*,*) '             Filename       = ', trim(file%filename)
+       write(*,*) '             Setname        = ', trim(setname)
+       write(*,*) '             HDF size       = ', ext
+       write(*,*) '             Requested size = ', int(s,i4b)
+       !write(*,*) opt_, 'Optional parameter'
+    end if
     call h5dread_f(file%sethandle, H5T_NATIVE_DOUBLE, val, s, file%status)
     call assert(file%status>=0, "comm_hdf_mod: Cannot read data from hdf set " // setname)
   end subroutine
@@ -1837,11 +1912,22 @@ contains
     real(sp) ,dimension(:,:), allocatable, intent(out) :: val
     integer(i4b) :: n(2)
     integer(hsize_t) :: s(2)
+    integer(i4b)     :: ext(2)
     if(allocated(val)) deallocate(val)
     call get_size_hdf(file, setname, n)
     allocate(val(n(1),n(2)))
     call open_hdf_set(file, setname)
     s = int(shape(val))
+    ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
+    if (any(ext /= s)) then
+       write(*,*) 'HDF error -- inconsistent array sizes'
+       write(*,*) '             Filename       = ', trim(file%filename)
+       write(*,*) '             Setname        = ', trim(setname)
+       write(*,*) '             HDF size       = ', ext
+       write(*,*) '             Requested size = ', int(s,i4b)
+       !write(*,*) opt_, 'Optional parameter'
+    end if
     call h5dread_f(file%sethandle, H5T_NATIVE_REAL, val, s, file%status)
     call assert(file%status>=0, "comm_hdf_mod: Cannot read data from hdf set " // setname)
   end subroutine
@@ -1853,11 +1939,22 @@ contains
     integer(i4b) ,dimension(:,:), allocatable, intent(out) :: val
     integer(i4b) :: n(2)
     integer(hsize_t) :: s(2)
+    integer(i4b)     :: ext(2)
     if(allocated(val)) deallocate(val)
     call get_size_hdf(file, setname, n)
     allocate(val(n(1),n(2)))
     call open_hdf_set(file, setname)
     s = int(shape(val))
+    ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
+    if (any(ext /= s)) then
+       write(*,*) 'HDF error -- inconsistent array sizes'
+       write(*,*) '             Filename       = ', trim(file%filename)
+       write(*,*) '             Setname        = ', trim(setname)
+       write(*,*) '             HDF size       = ', ext
+       write(*,*) '             Requested size = ', int(s,i4b)
+       !write(*,*) opt_, 'Optional parameter'
+    end if
     call h5dread_f(file%sethandle, H5T_NATIVE_INTEGER, val, s, file%status)
     call assert(file%status>=0, "comm_hdf_mod: Cannot read data from hdf set " // setname)
   end subroutine
@@ -1869,11 +1966,22 @@ contains
     character(len=*) ,dimension(:,:), allocatable, intent(out) :: val
     integer(i4b) :: n(2)
     integer(hsize_t) :: s(2)
+    integer(i4b)     :: ext(2)
     if(allocated(val)) deallocate(val)
     call get_size_hdf(file, setname, n)
     allocate(val(n(1),n(2)))
     call open_hdf_set(file, setname)
     s = int(shape(val))
+    ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
+    if (any(ext /= s)) then
+       write(*,*) 'HDF error -- inconsistent array sizes'
+       write(*,*) '             Filename       = ', trim(file%filename)
+       write(*,*) '             Setname        = ', trim(setname)
+       write(*,*) '             HDF size       = ', ext
+       write(*,*) '             Requested size = ', int(s,i4b)
+       !write(*,*) opt_, 'Optional parameter'
+    end if
     call h5dread_f(file%sethandle, H5T_NATIVE_CHARACTER, val, s, file%status)
     call assert(file%status>=0, "comm_hdf_mod: Cannot read data from hdf set " // setname)
   end subroutine
@@ -1885,11 +1993,22 @@ contains
     real(dp) ,dimension(:,:,:), allocatable, intent(out) :: val
     integer(i4b) :: n(3)
     integer(hsize_t) :: s(3)
+    integer(i4b)     :: ext(3)
     if(allocated(val)) deallocate(val)
     call get_size_hdf(file, setname, n)
     allocate(val(n(1),n(2),n(3)))
     call open_hdf_set(file, setname)
     s = int(shape(val))
+    ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
+    if (any(ext /= s)) then
+       write(*,*) 'HDF error -- inconsistent array sizes'
+       write(*,*) '             Filename       = ', trim(file%filename)
+       write(*,*) '             Setname        = ', trim(setname)
+       write(*,*) '             HDF size       = ', ext
+       write(*,*) '             Requested size = ', int(s,i4b)
+       !write(*,*) opt_, 'Optional parameter'
+    end if
     call h5dread_f(file%sethandle, H5T_NATIVE_DOUBLE, val, s, file%status)
     call assert(file%status>=0, "comm_hdf_mod: Cannot read data from hdf set " // setname)
   end subroutine
@@ -1901,11 +2020,22 @@ contains
     real(sp) ,dimension(:,:,:), allocatable, intent(out) :: val
     integer(i4b) :: n(3)
     integer(hsize_t) :: s(3)
+    integer(i4b)     :: ext(3)
     if(allocated(val)) deallocate(val)
     call get_size_hdf(file, setname, n)
     allocate(val(n(1),n(2),n(3)))
     call open_hdf_set(file, setname)
     s = int(shape(val))
+    ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
+    if (any(ext /= s)) then
+       write(*,*) 'HDF error -- inconsistent array sizes'
+       write(*,*) '             Filename       = ', trim(file%filename)
+       write(*,*) '             Setname        = ', trim(setname)
+       write(*,*) '             HDF size       = ', ext
+       write(*,*) '             Requested size = ', int(s,i4b)
+       !write(*,*) opt_, 'Optional parameter'
+    end if
     call h5dread_f(file%sethandle, H5T_NATIVE_REAL, val, s, file%status)
     call assert(file%status>=0, "comm_hdf_mod: Cannot read data from hdf set " // setname)
   end subroutine
@@ -1917,11 +2047,22 @@ contains
     integer(i4b) ,dimension(:,:,:), allocatable, intent(out) :: val
     integer(i4b) :: n(3)
     integer(hsize_t) :: s(3)
+    integer(i4b)     :: ext(3)
     if(allocated(val)) deallocate(val)
     call get_size_hdf(file, setname, n)
     allocate(val(n(1),n(2),n(3)))
     call open_hdf_set(file, setname)
     s = int(shape(val))
+    ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
+    if (any(ext /= s)) then
+       write(*,*) 'HDF error -- inconsistent array sizes'
+       write(*,*) '             Filename       = ', trim(file%filename)
+       write(*,*) '             Setname        = ', trim(setname)
+       write(*,*) '             HDF size       = ', ext
+       write(*,*) '             Requested size = ', int(s,i4b)
+       !write(*,*) opt_, 'Optional parameter'
+    end if
     call h5dread_f(file%sethandle, H5T_NATIVE_INTEGER, val, s, file%status)
     call assert(file%status>=0, "comm_hdf_mod: Cannot read data from hdf set " // setname)
   end subroutine
@@ -1933,11 +2074,22 @@ contains
     character(len=*) ,dimension(:,:,:), allocatable, intent(out) :: val
     integer(i4b) :: n(3)
     integer(hsize_t) :: s(3)
+    integer(i4b)     :: ext(3)
     if(allocated(val)) deallocate(val)
     call get_size_hdf(file, setname, n)
     allocate(val(n(1),n(2),n(3)))
     call open_hdf_set(file, setname)
     s = int(shape(val))
+    ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
+    if (any(ext /= s)) then
+       write(*,*) 'HDF error -- inconsistent array sizes'
+       write(*,*) '             Filename       = ', trim(file%filename)
+       write(*,*) '             Setname        = ', trim(setname)
+       write(*,*) '             HDF size       = ', ext
+       write(*,*) '             Requested size = ', int(s,i4b)
+       !write(*,*) opt_, 'Optional parameter'
+    end if
     call h5dread_f(file%sethandle, H5T_NATIVE_CHARACTER, val, s, file%status)
     call assert(file%status>=0, "comm_hdf_mod: Cannot read data from hdf set " // setname)
   end subroutine
@@ -1949,11 +2101,22 @@ contains
     real(dp) ,dimension(:,:,:,:), allocatable, intent(out) :: val
     integer(i4b) :: n(4)
     integer(hsize_t) :: s(4)
+    integer(i4b)     :: ext(4)
     if(allocated(val)) deallocate(val)
     call get_size_hdf(file, setname, n)
     allocate(val(n(1),n(2),n(3),n(4)))
     call open_hdf_set(file, setname)
     s = int(shape(val))
+    ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
+    if (any(ext /= s)) then
+       write(*,*) 'HDF error -- inconsistent array sizes'
+       write(*,*) '             Filename       = ', trim(file%filename)
+       write(*,*) '             Setname        = ', trim(setname)
+       write(*,*) '             HDF size       = ', ext
+       write(*,*) '             Requested size = ', int(s,i4b)
+       !write(*,*) opt_, 'Optional parameter'
+    end if
     call h5dread_f(file%sethandle, H5T_NATIVE_DOUBLE, val, s, file%status)
     call assert(file%status>=0, "comm_hdf_mod: Cannot read data from hdf set " // setname)
   end subroutine
@@ -1965,11 +2128,22 @@ contains
     real(sp) ,dimension(:,:,:,:), allocatable, intent(out) :: val
     integer(i4b) :: n(4)
     integer(hsize_t) :: s(4)
+    integer(i4b)     :: ext(4)
     if(allocated(val)) deallocate(val)
     call get_size_hdf(file, setname, n)
     allocate(val(n(1),n(2),n(3),n(4)))
     call open_hdf_set(file, setname)
     s = int(shape(val))
+    ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
+    if (any(ext /= s)) then
+       write(*,*) 'HDF error -- inconsistent array sizes'
+       write(*,*) '             Filename       = ', trim(file%filename)
+       write(*,*) '             Setname        = ', trim(setname)
+       write(*,*) '             HDF size       = ', ext
+       write(*,*) '             Requested size = ', int(s,i4b)
+       !write(*,*) opt_, 'Optional parameter'
+    end if
     call h5dread_f(file%sethandle, H5T_NATIVE_REAL, val, s, file%status)
     call assert(file%status>=0, "comm_hdf_mod: Cannot read data from hdf set " // setname)
   end subroutine
@@ -1981,11 +2155,22 @@ contains
     integer(i4b) ,dimension(:,:,:,:), allocatable, intent(out) :: val
     integer(i4b) :: n(4)
     integer(hsize_t) :: s(4)
+    integer(i4b)     :: ext(4)
     if(allocated(val)) deallocate(val)
     call get_size_hdf(file, setname, n)
     allocate(val(n(1),n(2),n(3),n(4)))
     call open_hdf_set(file, setname)
     s = int(shape(val))
+    ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
+    if (any(ext /= s)) then
+       write(*,*) 'HDF error -- inconsistent array sizes'
+       write(*,*) '             Filename       = ', trim(file%filename)
+       write(*,*) '             Setname        = ', trim(setname)
+       write(*,*) '             HDF size       = ', ext
+       write(*,*) '             Requested size = ', int(s,i4b)
+       !write(*,*) opt_, 'Optional parameter'
+    end if
     call h5dread_f(file%sethandle, H5T_NATIVE_INTEGER, val, s, file%status)
     call assert(file%status>=0, "comm_hdf_mod: Cannot read data from hdf set " // setname)
   end subroutine
@@ -1997,11 +2182,22 @@ contains
     character(len=*) ,dimension(:,:,:,:), allocatable, intent(out) :: val
     integer(i4b) :: n(4)
     integer(hsize_t) :: s(4)
+    integer(i4b)     :: ext(4)
     if(allocated(val)) deallocate(val)
     call get_size_hdf(file, setname, n)
     allocate(val(n(1),n(2),n(3),n(4)))
     call open_hdf_set(file, setname)
     s = int(shape(val))
+    ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
+    if (any(ext /= s)) then
+       write(*,*) 'HDF error -- inconsistent array sizes'
+       write(*,*) '             Filename       = ', trim(file%filename)
+       write(*,*) '             Setname        = ', trim(setname)
+       write(*,*) '             HDF size       = ', ext
+       write(*,*) '             Requested size = ', int(s,i4b)
+       !write(*,*) opt_, 'Optional parameter'
+    end if
     call h5dread_f(file%sethandle, H5T_NATIVE_CHARACTER, val, s, file%status)
     call assert(file%status>=0, "comm_hdf_mod: Cannot read data from hdf set " // setname)
   end subroutine
@@ -2013,11 +2209,22 @@ contains
     real(dp) ,dimension(:,:,:,:,:), allocatable, intent(out) :: val
     integer(i4b) :: n(5)
     integer(hsize_t) :: s(5)
+    integer(i4b)     :: ext(5)
     if(allocated(val)) deallocate(val)
     call get_size_hdf(file, setname, n)
     allocate(val(n(1),n(2),n(3),n(4),n(5)))
     call open_hdf_set(file, setname)
     s = int(shape(val))
+    ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
+    if (any(ext /= s)) then
+       write(*,*) 'HDF error -- inconsistent array sizes'
+       write(*,*) '             Filename       = ', trim(file%filename)
+       write(*,*) '             Setname        = ', trim(setname)
+       write(*,*) '             HDF size       = ', ext
+       write(*,*) '             Requested size = ', int(s,i4b)
+       !write(*,*) opt_, 'Optional parameter'
+    end if
     call h5dread_f(file%sethandle, H5T_NATIVE_DOUBLE, val, s, file%status)
     call assert(file%status>=0, "comm_hdf_mod: Cannot read data from hdf set " // setname)
   end subroutine
@@ -2029,11 +2236,22 @@ contains
     real(sp) ,dimension(:,:,:,:,:), allocatable, intent(out) :: val
     integer(i4b) :: n(5)
     integer(hsize_t) :: s(5)
+    integer(i4b)     :: ext(5)
     if(allocated(val)) deallocate(val)
     call get_size_hdf(file, setname, n)
     allocate(val(n(1),n(2),n(3),n(4),n(5)))
     call open_hdf_set(file, setname)
     s = int(shape(val))
+    ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
+    if (any(ext /= s)) then
+       write(*,*) 'HDF error -- inconsistent array sizes'
+       write(*,*) '             Filename       = ', trim(file%filename)
+       write(*,*) '             Setname        = ', trim(setname)
+       write(*,*) '             HDF size       = ', ext
+       write(*,*) '             Requested size = ', int(s,i4b)
+       !write(*,*) opt_, 'Optional parameter'
+    end if
     call h5dread_f(file%sethandle, H5T_NATIVE_REAL, val, s, file%status)
     call assert(file%status>=0, "comm_hdf_mod: Cannot read data from hdf set " // setname)
   end subroutine
@@ -2045,11 +2263,22 @@ contains
     integer(i4b) ,dimension(:,:,:,:,:), allocatable, intent(out) :: val
     integer(i4b) :: n(5)
     integer(hsize_t) :: s(5)
+    integer(i4b)     :: ext(5)
     if(allocated(val)) deallocate(val)
     call get_size_hdf(file, setname, n)
     allocate(val(n(1),n(2),n(3),n(4),n(5)))
     call open_hdf_set(file, setname)
     s = int(shape(val))
+    ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
+    if (any(ext /= s)) then
+       write(*,*) 'HDF error -- inconsistent array sizes'
+       write(*,*) '             Filename       = ', trim(file%filename)
+       write(*,*) '             Setname        = ', trim(setname)
+       write(*,*) '             HDF size       = ', ext
+       write(*,*) '             Requested size = ', int(s,i4b)
+       !write(*,*) opt_, 'Optional parameter'
+    end if
     call h5dread_f(file%sethandle, H5T_NATIVE_INTEGER, val, s, file%status)
     call assert(file%status>=0, "comm_hdf_mod: Cannot read data from hdf set " // setname)
   end subroutine
@@ -2061,11 +2290,22 @@ contains
     character(len=*) ,dimension(:,:,:,:,:), allocatable, intent(out) :: val
     integer(i4b) :: n(5)
     integer(hsize_t) :: s(5)
+    integer(i4b)     :: ext(5)
     if(allocated(val)) deallocate(val)
     call get_size_hdf(file, setname, n)
     allocate(val(n(1),n(2),n(3),n(4),n(5)))
     call open_hdf_set(file, setname)
     s = int(shape(val))
+    ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
+    if (any(ext /= s)) then
+       write(*,*) 'HDF error -- inconsistent array sizes'
+       write(*,*) '             Filename       = ', trim(file%filename)
+       write(*,*) '             Setname        = ', trim(setname)
+       write(*,*) '             HDF size       = ', ext
+       write(*,*) '             Requested size = ', int(s,i4b)
+       !write(*,*) opt_, 'Optional parameter'
+    end if
     call h5dread_f(file%sethandle, H5T_NATIVE_CHARACTER, val, s, file%status)
     call assert(file%status>=0, "comm_hdf_mod: Cannot read data from hdf set " // setname)
   end subroutine
@@ -2077,11 +2317,22 @@ contains
     real(dp) ,dimension(:,:,:,:,:,:), allocatable, intent(out) :: val
     integer(i4b) :: n(6)
     integer(hsize_t) :: s(6)
+    integer(i4b)     :: ext(6)
     if(allocated(val)) deallocate(val)
     call get_size_hdf(file, setname, n)
     allocate(val(n(1),n(2),n(3),n(4),n(5),n(6)))
     call open_hdf_set(file, setname)
     s = int(shape(val))
+    ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
+    if (any(ext /= s)) then
+       write(*,*) 'HDF error -- inconsistent array sizes'
+       write(*,*) '             Filename       = ', trim(file%filename)
+       write(*,*) '             Setname        = ', trim(setname)
+       write(*,*) '             HDF size       = ', ext
+       write(*,*) '             Requested size = ', int(s,i4b)
+       !write(*,*) opt_, 'Optional parameter'
+    end if
     call h5dread_f(file%sethandle, H5T_NATIVE_DOUBLE, val, s, file%status)
     call assert(file%status>=0, "comm_hdf_mod: Cannot read data from hdf set " // setname)
   end subroutine
@@ -2093,11 +2344,22 @@ contains
     real(sp) ,dimension(:,:,:,:,:,:), allocatable, intent(out) :: val
     integer(i4b) :: n(6)
     integer(hsize_t) :: s(6)
+    integer(i4b)     :: ext(6)
     if(allocated(val)) deallocate(val)
     call get_size_hdf(file, setname, n)
     allocate(val(n(1),n(2),n(3),n(4),n(5),n(6)))
     call open_hdf_set(file, setname)
     s = int(shape(val))
+    ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
+    if (any(ext /= s)) then
+       write(*,*) 'HDF error -- inconsistent array sizes'
+       write(*,*) '             Filename       = ', trim(file%filename)
+       write(*,*) '             Setname        = ', trim(setname)
+       write(*,*) '             HDF size       = ', ext
+       write(*,*) '             Requested size = ', int(s,i4b)
+       !write(*,*) opt_, 'Optional parameter'
+    end if
     call h5dread_f(file%sethandle, H5T_NATIVE_REAL, val, s, file%status)
     call assert(file%status>=0, "comm_hdf_mod: Cannot read data from hdf set " // setname)
   end subroutine
@@ -2109,11 +2371,22 @@ contains
     integer(i4b) ,dimension(:,:,:,:,:,:), allocatable, intent(out) :: val
     integer(i4b) :: n(6)
     integer(hsize_t) :: s(6)
+    integer(i4b)     :: ext(6)
     if(allocated(val)) deallocate(val)
     call get_size_hdf(file, setname, n)
     allocate(val(n(1),n(2),n(3),n(4),n(5),n(6)))
     call open_hdf_set(file, setname)
     s = int(shape(val))
+    ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
+    if (any(ext /= s)) then
+       write(*,*) 'HDF error -- inconsistent array sizes'
+       write(*,*) '             Filename       = ', trim(file%filename)
+       write(*,*) '             Setname        = ', trim(setname)
+       write(*,*) '             HDF size       = ', ext
+       write(*,*) '             Requested size = ', int(s,i4b)
+       !write(*,*) opt_, 'Optional parameter'
+    end if
     call h5dread_f(file%sethandle, H5T_NATIVE_INTEGER, val, s, file%status)
     call assert(file%status>=0, "comm_hdf_mod: Cannot read data from hdf set " // setname)
   end subroutine
@@ -2125,11 +2398,22 @@ contains
     character(len=*) ,dimension(:,:,:,:,:,:), allocatable, intent(out) :: val
     integer(i4b) :: n(6)
     integer(hsize_t) :: s(6)
+    integer(i4b)     :: ext(6)
     if(allocated(val)) deallocate(val)
     call get_size_hdf(file, setname, n)
     allocate(val(n(1),n(2),n(3),n(4),n(5),n(6)))
     call open_hdf_set(file, setname)
     s = int(shape(val))
+    ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
+    if (any(ext /= s)) then
+       write(*,*) 'HDF error -- inconsistent array sizes'
+       write(*,*) '             Filename       = ', trim(file%filename)
+       write(*,*) '             Setname        = ', trim(setname)
+       write(*,*) '             HDF size       = ', ext
+       write(*,*) '             Requested size = ', int(s,i4b)
+       !write(*,*) opt_, 'Optional parameter'
+    end if
     call h5dread_f(file%sethandle, H5T_NATIVE_CHARACTER, val, s, file%status)
     call assert(file%status>=0, "comm_hdf_mod: Cannot read data from hdf set " // setname)
   end subroutine
@@ -2141,11 +2425,22 @@ contains
     real(dp) ,dimension(:,:,:,:,:,:,:), allocatable, intent(out) :: val
     integer(i4b) :: n(7)
     integer(hsize_t) :: s(7)
+    integer(i4b)     :: ext(7)
     if(allocated(val)) deallocate(val)
     call get_size_hdf(file, setname, n)
     allocate(val(n(1),n(2),n(3),n(4),n(5),n(6),n(7)))
     call open_hdf_set(file, setname)
     s = int(shape(val))
+    ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
+    if (any(ext /= s)) then
+       write(*,*) 'HDF error -- inconsistent array sizes'
+       write(*,*) '             Filename       = ', trim(file%filename)
+       write(*,*) '             Setname        = ', trim(setname)
+       write(*,*) '             HDF size       = ', ext
+       write(*,*) '             Requested size = ', int(s,i4b)
+       !write(*,*) opt_, 'Optional parameter'
+    end if
     call h5dread_f(file%sethandle, H5T_NATIVE_DOUBLE, val, s, file%status)
     call assert(file%status>=0, "comm_hdf_mod: Cannot read data from hdf set " // setname)
   end subroutine
@@ -2157,11 +2452,22 @@ contains
     real(sp) ,dimension(:,:,:,:,:,:,:), allocatable, intent(out) :: val
     integer(i4b) :: n(7)
     integer(hsize_t) :: s(7)
+    integer(i4b)     :: ext(7)
     if(allocated(val)) deallocate(val)
     call get_size_hdf(file, setname, n)
     allocate(val(n(1),n(2),n(3),n(4),n(5),n(6),n(7)))
     call open_hdf_set(file, setname)
     s = int(shape(val))
+    ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
+    if (any(ext /= s)) then
+       write(*,*) 'HDF error -- inconsistent array sizes'
+       write(*,*) '             Filename       = ', trim(file%filename)
+       write(*,*) '             Setname        = ', trim(setname)
+       write(*,*) '             HDF size       = ', ext
+       write(*,*) '             Requested size = ', int(s,i4b)
+       !write(*,*) opt_, 'Optional parameter'
+    end if
     call h5dread_f(file%sethandle, H5T_NATIVE_REAL, val, s, file%status)
     call assert(file%status>=0, "comm_hdf_mod: Cannot read data from hdf set " // setname)
   end subroutine
@@ -2173,11 +2479,22 @@ contains
     integer(i4b) ,dimension(:,:,:,:,:,:,:), allocatable, intent(out) :: val
     integer(i4b) :: n(7)
     integer(hsize_t) :: s(7)
+    integer(i4b)     :: ext(7)
     if(allocated(val)) deallocate(val)
     call get_size_hdf(file, setname, n)
     allocate(val(n(1),n(2),n(3),n(4),n(5),n(6),n(7)))
     call open_hdf_set(file, setname)
     s = int(shape(val))
+    ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
+    if (any(ext /= s)) then
+       write(*,*) 'HDF error -- inconsistent array sizes'
+       write(*,*) '             Filename       = ', trim(file%filename)
+       write(*,*) '             Setname        = ', trim(setname)
+       write(*,*) '             HDF size       = ', ext
+       write(*,*) '             Requested size = ', int(s,i4b)
+       !write(*,*) opt_, 'Optional parameter'
+    end if
     call h5dread_f(file%sethandle, H5T_NATIVE_INTEGER, val, s, file%status)
     call assert(file%status>=0, "comm_hdf_mod: Cannot read data from hdf set " // setname)
   end subroutine
@@ -2189,11 +2506,22 @@ contains
     character(len=*) ,dimension(:,:,:,:,:,:,:), allocatable, intent(out) :: val
     integer(i4b) :: n(7)
     integer(hsize_t) :: s(7)
+    integer(i4b)     :: ext(7)
     if(allocated(val)) deallocate(val)
     call get_size_hdf(file, setname, n)
     allocate(val(n(1),n(2),n(3),n(4),n(5),n(6),n(7)))
     call open_hdf_set(file, setname)
     s = int(shape(val))
+    ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
+    if (any(ext /= s)) then
+       write(*,*) 'HDF error -- inconsistent array sizes'
+       write(*,*) '             Filename       = ', trim(file%filename)
+       write(*,*) '             Setname        = ', trim(setname)
+       write(*,*) '             HDF size       = ', ext
+       write(*,*) '             Requested size = ', int(s,i4b)
+       !write(*,*) opt_, 'Optional parameter'
+    end if
     call h5dread_f(file%sethandle, H5T_NATIVE_CHARACTER, val, s, file%status)
     call assert(file%status>=0, "comm_hdf_mod: Cannot read data from hdf set " // setname)
   end subroutine

--- a/commander3/src/comm_hdf_mod.f90.in
+++ b/commander3/src/comm_hdf_mod.f90.in
@@ -247,6 +247,16 @@ contains
     call get_size_hdf(file, setname, ext)
     allocate(buffer(ext(1),ext(2)))
     ext2 = ext
+    ! Validate that sizes are consistent
+    !call get_size_hdf(file, setname, ext)
+    if (any(ext /= s)) then
+       write(*,*) 'HDF error -- inconsistent array sizes'
+       write(*,*) '             Filename       = ', trim(file%filename)
+       write(*,*) '             Setname        = ', trim(setname)
+       write(*,*) '             HDF size       = ', ext
+       write(*,*) '             Requested size = ', int(s,i4b)
+       !write(*,*) opt_, 'Optional parameter'
+    end if
     call h5dread_f(file%sethandle, H5T_NATIVE_DOUBLE, buffer, ext2, file%status)
     val = buffer(1:s(1),1:s(2))
     deallocate(buffer)
@@ -274,6 +284,16 @@ contains
     call get_size_hdf(file, setname, ext)
     allocate(buffer(ext(1),ext(2)))
     ext2 = ext
+    ! Validate that sizes are consistent
+    !call get_size_hdf(file, setname, ext)
+    if (any(ext /= s)) then
+       write(*,*) 'HDF error -- inconsistent array sizes'
+       write(*,*) '             Filename       = ', trim(file%filename)
+       write(*,*) '             Setname        = ', trim(setname)
+       write(*,*) '             HDF size       = ', ext
+       write(*,*) '             Requested size = ', int(s,i4b)
+       !write(*,*) opt_, 'Optional parameter'
+    end if
     call h5dread_f(file%sethandle, H5T_NATIVE_INTEGER, buffer, ext2, file%status)
     val = buffer(1:s(1),1:s(2))
     deallocate(buffer)
@@ -310,8 +330,8 @@ contains
     end if
     call open_hdf_set(file, setname)
     s = int(shape(val))
-    call get_size_hdf(file, setname, ext)
     ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
     if (any(ext /= s)) then
        write(*,*) 'HDF error -- inconsistent array sizes'
        write(*,*) '             Filename       = ', trim(file%filename)
@@ -336,11 +356,22 @@ contains
     {{t[1]}}({{t[2]}}) {{dims(d)}}, allocatable, intent(out) :: val
     integer(i4b) :: n({{d}})
     integer(hsize_t) :: s({{d}})
+    integer(i4b)     :: ext({{d}})
     if(allocated(val)) deallocate(val)
     call get_size_hdf(file, setname, n)
     allocate(val({{",".join(["n(%d)" % (i+1) for i in range(d)])}}))
     call open_hdf_set(file, setname)
     s = int(shape(val))
+    ! Validate that sizes are consistent
+    call get_size_hdf(file, setname, ext)
+    if (any(ext /= s)) then
+       write(*,*) 'HDF error -- inconsistent array sizes'
+       write(*,*) '             Filename       = ', trim(file%filename)
+       write(*,*) '             Setname        = ', trim(setname)
+       write(*,*) '             HDF size       = ', ext
+       write(*,*) '             Requested size = ', int(s,i4b)
+       !write(*,*) opt_, 'Optional parameter'
+    end if
     call h5dread_f(file%sethandle, {{t[4]}}, val, s, file%status)
     call assert(file%status>=0, "comm_hdf_mod: Cannot read data from hdf set " // setname)
   end subroutine

--- a/commander3/src/comm_param_mod.f90
+++ b/commander3/src/comm_param_mod.f90
@@ -1996,7 +1996,8 @@ contains
           call validate_file(trim(datadir)//trim(cpar%ds_tod_procmask1(i)))  ! Procmask1
           call validate_file(trim(datadir)//trim(cpar%ds_tod_procmask2(i)))  ! Procmask2
           call validate_file(trim(datadir)//trim(cpar%ds_tod_filelist(i)))   ! Filelist
-          call validate_file(trim(datadir)//trim(cpar%ds_tod_jumplist(i)))   ! Jumplist
+          if (trim(cpar%ds_tod_jumplist(i)) /= 'none') &
+               & call validate_file(trim(datadir)//trim(cpar%ds_tod_jumplist(i)))   ! Jumplist
           call validate_file(trim(datadir)//trim(cpar%ds_tod_instfile(i)))   ! Instrument file, RIMO
           call validate_file(trim(datadir)//trim(cpar%ds_tod_bp_init(i)))    ! BP prop and init
        end if

--- a/commander3/src/comm_tod_LFI_mod.f90
+++ b/commander3/src/comm_tod_LFI_mod.f90
@@ -67,7 +67,7 @@ module comm_tod_LFI_mod
 
 
   type, extends(comm_tod) :: comm_LFI_tod
-    class(orbdipole_pointer), allocatable :: orb_dp !orbital dipole calculator
+     class(orbdipole_pointer), allocatable :: orb_dp !orbital dipole calculator
    contains
      procedure     :: process_tod        => process_LFI_tod
      procedure     :: simulate_LFI_tod
@@ -102,34 +102,37 @@ contains
 
     ! Set up LFI specific parameters
     allocate(constructor)
-    constructor%tod_type      = tod_type
-    constructor%myid          = cpar%myid_chain
-    constructor%comm          = cpar%comm_chain
-    constructor%numprocs      = cpar%numprocs_chain
-    constructor%myid_shared   = cpar%myid_shared
-    constructor%comm_shared   = cpar%comm_shared
-    constructor%myid_inter    = cpar%myid_inter
-    constructor%comm_inter    = cpar%comm_inter
-    constructor%info          => info
-    constructor%init_from_HDF = cpar%ds_tod_initHDF(id_abs)
-    constructor%freq          = cpar%ds_label(id_abs)
-    constructor%operation     = cpar%operation
-    constructor%outdir        = cpar%outdir
-    constructor%first_call    = .true.
-    constructor%first_scan    = cpar%ds_tod_scanrange(id_abs,1)
-    constructor%last_scan     = cpar%ds_tod_scanrange(id_abs,2)
-    constructor%flag0         = cpar%ds_tod_flag(id_abs)
-    constructor%orb_abscal    = cpar%ds_tod_orb_abscal(id_abs)
-    constructor%nscan_tot     = cpar%ds_tod_tot_numscan(id_abs)
-    constructor%output_4D_map = cpar%output_4D_map_nth_iter
+    constructor%tod_type        = tod_type
+    constructor%myid            = cpar%myid_chain
+    constructor%comm            = cpar%comm_chain
+    constructor%numprocs        = cpar%numprocs_chain
+    constructor%myid_shared     = cpar%myid_shared
+    constructor%comm_shared     = cpar%comm_shared
+    constructor%myid_inter      = cpar%myid_inter
+    constructor%comm_inter      = cpar%comm_inter
+    constructor%info            => info
+    constructor%init_from_HDF   = cpar%ds_tod_initHDF(id_abs)
+    constructor%freq            = cpar%ds_label(id_abs)
+    constructor%operation       = cpar%operation
+    constructor%outdir          = cpar%outdir
+    constructor%first_call      = .true.
+    constructor%first_scan      = cpar%ds_tod_scanrange(id_abs,1)
+    constructor%last_scan       = cpar%ds_tod_scanrange(id_abs,2)
+    constructor%flag0           = cpar%ds_tod_flag(id_abs)
+    constructor%orb_abscal      = cpar%ds_tod_orb_abscal(id_abs)
+    constructor%nscan_tot       = cpar%ds_tod_tot_numscan(id_abs)
+    constructor%output_4D_map   = cpar%output_4D_map_nth_iter
     constructor%output_aux_maps = cpar%output_aux_maps
-    constructor%subtract_zodi = cpar%include_TOD_zodi
-    constructor%central_freq  = cpar%ds_nu_c(id_abs)
+    constructor%subtract_zodi   = cpar%include_TOD_zodi
+    constructor%central_freq    = cpar%ds_nu_c(id_abs)
     constructor%samprate_lowres = 1.d0  ! Lowres samprate in Hz
-    constructor%halfring_split = cpar%ds_tod_halfring(id_abs)
-    constructor%nside_param   = cpar%ds_nside(id_abs)
-    constructor%compressed_tod = .false.
-    constructor%verbosity     = cpar%verbosity
+    constructor%halfring_split  = cpar%ds_tod_halfring(id_abs)
+    constructor%nside_param     = cpar%ds_nside(id_abs)
+    constructor%compressed_tod  = .false.
+    constructor%correct_sl      = .true.
+    constructor%sample_mono     = .false.
+    constructor%verbosity       = cpar%verbosity
+    constructor%orb_4pi_beam    = .true.
 
     !----------------------------------------------------------------------------------
     ! Simulation Routine
@@ -463,6 +466,8 @@ contains
     call wall_time(t2); t_tot(13) = t2-t1
 
     call update_status(status, "tod_init")
+
+
 
     ! Compute output map and rms
     call wall_time(t3)

--- a/commander3/src/comm_tod_LFI_mod.f90
+++ b/commander3/src/comm_tod_LFI_mod.f90
@@ -41,7 +41,6 @@ module comm_tod_LFI_mod
   type, extends(comm_tod) :: comm_LFI_tod
    contains
      procedure     :: process_tod        => process_LFI_tod
-     procedure     :: simulate_LFI_tod
   end type comm_LFI_tod
 
   interface comm_LFI_tod
@@ -61,101 +60,33 @@ contains
     character(len=128),      intent(in) :: tod_type
     class(comm_LFI_tod),     pointer    :: constructor
 
-    integer(i4b) :: i, j, k, nside_beam, lmax_beam, nmaps_beam, ndelta, np_vec, ierr, offset
-    real(dp)     :: f_fill, f_fill_lim(3), theta, phi, pixVal
-    character(len=512) :: datadir
+    integer(i4b) :: i, nside_beam, lmax_beam, nmaps_beam, ierr
     logical(lgt) :: pol_beam
-    type(hdf_file) :: h5_file
-    integer(i4b), allocatable, dimension(:) :: pix
-    real(dp), dimension(3) :: v
-    character(len=10) :: fieldname
-    class(tod_pointer), pointer :: selfptr
 
-    ! Set up LFI specific parameters
+    ! Initialize common parameters
     allocate(constructor)
-    constructor%tod_type        = tod_type
-    constructor%myid            = cpar%myid_chain
-    constructor%comm            = cpar%comm_chain
-    constructor%numprocs        = cpar%numprocs_chain
-    constructor%myid_shared     = cpar%myid_shared
-    constructor%comm_shared     = cpar%comm_shared
-    constructor%myid_inter      = cpar%myid_inter
-    constructor%comm_inter      = cpar%comm_inter
-    constructor%info            => info
-    constructor%init_from_HDF   = cpar%ds_tod_initHDF(id_abs)
-    constructor%freq            = cpar%ds_label(id_abs)
-    constructor%operation       = cpar%operation
-    constructor%outdir          = cpar%outdir
-    constructor%first_call      = .true.
-    constructor%first_scan      = cpar%ds_tod_scanrange(id_abs,1)
-    constructor%last_scan       = cpar%ds_tod_scanrange(id_abs,2)
-    constructor%flag0           = cpar%ds_tod_flag(id_abs)
-    constructor%orb_abscal      = cpar%ds_tod_orb_abscal(id_abs)
-    constructor%nscan_tot       = cpar%ds_tod_tot_numscan(id_abs)
-    constructor%output_4D_map   = cpar%output_4D_map_nth_iter
-    constructor%output_aux_maps = cpar%output_aux_maps
-    constructor%subtract_zodi   = cpar%include_TOD_zodi
-    constructor%central_freq    = cpar%ds_nu_c(id_abs)
+    call constructor%tod_constructor(cpar, id_abs, info, tod_type)
+
+    ! Initialize instrument-specific parameters
     constructor%samprate_lowres = 1.d0  ! Lowres samprate in Hz
-    constructor%halfring_split  = cpar%ds_tod_halfring(id_abs)
-    constructor%nside_param     = cpar%ds_nside(id_abs)
+    constructor%nhorn           = 1
     constructor%compressed_tod  = .false.
     constructor%correct_sl      = .true.
-    constructor%verbosity       = cpar%verbosity
     constructor%orb_4pi_beam    = .true.
     constructor%symm_flags      = .true.
     constructor%chisq_threshold = 20.d0 ! 9.d0
+    constructor%nmaps           = info%nmaps
+    constructor%ndet            = num_tokens(cpar%ds_tod_dets(id_abs), ",")
 
-    !----------------------------------------------------------------------------------
-    ! Simulation Routine
-    !----------------------------------------------------------------------------------
-    constructor%sims_output_dir = cpar%sims_output_dir
-    constructor%enable_tod_simulations = cpar%enable_tod_simulations
-    !----------------------------------------------------------------------------------
+    nside_beam                  = 512
+    nmaps_beam                  = 3
+    pol_beam                    = .true.
+    constructor%nside_beam      = nside_beam
 
-    call mpi_comm_size(cpar%comm_shared, constructor%numprocs_shared, ierr)
-
-    if (constructor%first_scan > constructor%last_scan) then
-       write(*,*) 'Error: First scan larger than last scan for ', trim(constructor%freq)
-       call mpi_finalize(ierr)
-       stop
-    end if
-
-    datadir = trim(cpar%datadir)//'/'
-    constructor%filelist    = trim(datadir)//trim(cpar%ds_tod_filelist(id_abs))
-    constructor%procmaskf1  = trim(datadir)//trim(cpar%ds_tod_procmask1(id_abs))
-    constructor%procmaskf2  = trim(datadir)//trim(cpar%ds_tod_procmask2(id_abs))
-    constructor%instfile    = trim(datadir)//trim(cpar%ds_tod_instfile(id_abs))
-
-    call constructor%get_scan_ids(constructor%filelist)
-
-    constructor%procmask => comm_map(constructor%info, constructor%procmaskf1)
-    constructor%procmask2 => comm_map(constructor%info, constructor%procmaskf2)
-    do i = 0, constructor%info%np-1
-       if (any(constructor%procmask%map(i,:) < 0.5d0)) then
-          constructor%procmask%map(i,:) = 0.d0
-       else
-          constructor%procmask%map(i,:) = 1.d0
-       end if
-       if (any(constructor%procmask2%map(i,:) < 0.5d0)) then
-          constructor%procmask2%map(i,:) = 0.d0
-       else
-          constructor%procmask2%map(i,:) = 1.d0
-       end if
-    end do
-
-
-    constructor%nmaps    = info%nmaps
-    constructor%ndet     = num_tokens(cpar%ds_tod_dets(id_abs), ",")
-    constructor%nhorn    = 1
-    allocate(constructor%stokes(constructor%nmaps))
-    allocate(constructor%w(constructor%nmaps,constructor%nhorn,constructor%ndet))
-    allocate(constructor%label(constructor%ndet))
-    allocate(constructor%partner(constructor%ndet))
-    allocate(constructor%horn_id(constructor%ndet))
-    constructor%stokes = [1,2,3]
-    constructor%w      = 1.d0
+    ! Get detector labels
     call get_tokens(cpar%ds_tod_dets(id_abs), ",", constructor%label)
+    
+    ! Define detector partners
     do i = 1, constructor%ndet
        if (mod(i,2) == 1) then
           constructor%partner(i) = i+1
@@ -164,123 +95,27 @@ contains
        end if
        constructor%horn_id(i) = (i+1)/2
     end do
-
-    call constructor%read_jumplist(datadir, cpar%ds_tod_jumplist(id_abs))
-
-    if (trim(cpar%ds_bpmodel(id_abs)) == 'additive_shift') then
-       ndelta = 1
-    else if (trim(cpar%ds_bpmodel(id_abs)) == 'powlaw_tilt') then
-       ndelta = 1
-    else
-       write(*,*) 'Unknown bandpass model'
-       stop
-    end if
-    allocate(constructor%bp_delta(0:constructor%ndet,ndelta))
-    constructor%bp_delta = 0.d0
-
+      
     ! Read the actual TOD
     call constructor%read_tod(constructor%label)
 
     ! Initialize bandpass mean and proposal matrix
-    call constructor%initialize_bp_covar(trim(datadir)//cpar%ds_tod_bp_init(id_abs))
+    call constructor%initialize_bp_covar(trim(cpar%datadir)//'/'//cpar%ds_tod_bp_init(id_abs))
 
-    ! Initialize beams
-    allocate(constructor%fwhm(constructor%ndet))
-    allocate(constructor%elip(constructor%ndet))
-    allocate(constructor%psi_ell(constructor%ndet))
-    allocate(constructor%mb_eff(constructor%ndet))
-    allocate(constructor%nu_c(constructor%ndet))
+    ! Construct lookup tables
+    call constructor%precompute_lookups()
 
-    call open_hdf_file(constructor%instfile, h5_file, 'r')
-    nside_beam = 512
-    nmaps_beam = 3
-    pol_beam   = .true.
-    call read_hdf(h5_file, trim(adjustl(constructor%label(1)))//'/'//'sllmax', lmax_beam)
-    constructor%slinfo => comm_mapinfo(cpar%comm_chain, nside_beam, lmax_beam, &
-         & nmaps_beam, pol_beam)
+    ! Load the instrument file
+    call constructor%load_instrument_file(nside_beam, nmaps_beam, pol_beam, cpar%comm_chain)
 
-    allocate(constructor%slbeam(constructor%ndet), constructor%slconv(constructor%ndet))
-    allocate(constructor%mbeam(constructor%ndet))
+    ! Allocate sidelobe convolution data structures
+    allocate(constructor%slconv(constructor%ndet), constructor%orb_dp)
+    constructor%orb_dp => comm_orbdipole(constructor%mbeam)
 
-    do i = 1, constructor%ndet
-       constructor%slbeam(i)%p => comm_map(constructor%slinfo, h5_file, .true., "sl", &
-            & trim(constructor%label(i)))
-       constructor%mbeam(i)%p => comm_map(constructor%slinfo, h5_file, .true., "beam", trim(constructor%label(i)))
-       call constructor%mbeam(i)%p%Y()
-    end do
-
-    do i = 1, constructor%ndet
-       call read_hdf(h5_file, trim(adjustl(constructor%label(i)))//'/'//'fwhm', constructor%fwhm(i))
-       call read_hdf(h5_file, trim(adjustl(constructor%label(i)))//'/'//'elip', constructor%elip(i))
-       call read_hdf(h5_file, trim(adjustl(constructor%label(i)))//'/'//'psi_ell', constructor%psi_ell(i))
-       call read_hdf(h5_file, trim(adjustl(constructor%label(i)))//'/'//'mbeam_eff', constructor%mb_eff(i))
-       call read_hdf(h5_file, trim(adjustl(constructor%label(i)))//'/'//'centFreq', constructor%nu_c(i))
-    end do
-
-    constructor%mb_eff = 1.d0
-    constructor%mb_eff = constructor%mb_eff / mean(constructor%mb_eff)
-    constructor%nu_c   = constructor%nu_c * 1d9
-
-    call close_hdf_file(h5_file)
-
-    ! Lastly, create a vector pointing table for fast look-up for orbital dipole
-    np_vec = 12*constructor%nside**2 !npix
-    allocate(constructor%pix2vec(3,0:np_vec-1))
-    do i = 0, np_vec-1
-       call pix2vec_ring(constructor%nside, i, constructor%pix2vec(:,i))
-    end do
-
-    ! Construct observed pixel array
-    allocate(constructor%pix2ind(0:12*constructor%nside**2-1))
-    constructor%pix2ind = -1
-    do i = 1, constructor%nscan
-       allocate(pix(constructor%scans(i)%ntod))
-       offset = 0
-       if(constructor%halfring_split == 2) then
-         offset = constructor%scans(i)%ntod
-       end if
-       do j = 1, constructor%ndet
-          call huffman_decode(constructor%scans(i)%hkey, &
-               constructor%scans(i)%d(j)%pix(1)%p, pix)
-          constructor%pix2ind(pix(1)) = 1
-          do k = 2, constructor%scans(i)%ntod
-             pix(k)  = pix(k-1)  + pix(k)
-             constructor%pix2ind(pix(k)) = 1
-          end do
-       end do
-       deallocate(pix)
-    end do
-    constructor%nobs = count(constructor%pix2ind == 1)
-    allocate(constructor%ind2pix(constructor%nobs))
-    allocate(constructor%ind2sl(constructor%nobs))
-    allocate(constructor%ind2ang(2,constructor%nobs))
-    j = 1
-    do i = 0, 12*constructor%nside**2-1
-       if (constructor%pix2ind(i) == 1) then
-          constructor%ind2pix(j) = i
-          constructor%pix2ind(i) = j
-          call pix2ang_ring(constructor%nside, i, theta, phi)
-          call ang2pix_ring(nside_beam, theta, phi, constructor%ind2sl(j))
-          constructor%ind2ang(:,j) = [theta,phi]
-          j = j+1
-       end if
-    end do
-    f_fill = constructor%nobs/(12.*constructor%nside**2)
-    call mpi_reduce(f_fill, f_fill_lim(1), 1, MPI_DOUBLE_PRECISION, MPI_MIN, 0, constructor%info%comm, ierr)
-    call mpi_reduce(f_fill, f_fill_lim(2), 1, MPI_DOUBLE_PRECISION, MPI_MAX, 0, constructor%info%comm, ierr)
-    call mpi_reduce(f_fill, f_fill_lim(3), 1, MPI_DOUBLE_PRECISION, MPI_SUM, 0, constructor%info%comm, ierr)
-    if (constructor%myid == 0) then
-       write(*,*) '  Min/mean/max TOD-map f_sky = ', real(100*f_fill_lim(1),sp), real(100*f_fill_lim(3)/constructor%info%nprocs,sp), real(100*f_fill_lim(2),sp)
-    end if
-
-    ! Set all baseline corrections to zero
+    ! Initialize all baseline corrections to zero
     do i = 1, constructor%nscan
        constructor%scans(i)%d%baseline = 0.d0
     end do
-
-    ! Allocate orbital dipole object
-    allocate(constructor%orb_dp)
-    constructor%orb_dp => comm_orbdipole(constructor%mbeam)
 
   end function constructor
 
@@ -408,7 +243,7 @@ contains
 
        ! Calling Simulation Routine
        if (self%enable_tod_simulations) then
-          call self%simulate_LFI_tod(i, sd%s_tot, handle)
+          call simulate_tod(self, i, sd%s_tot, handle)
           call sd%dealloc
           cycle
        end if
@@ -512,193 +347,5 @@ contains
     call update_status(status, "tod_end"//ctext)
 
   end subroutine process_LFI_tod
-
-  ! ************************************************
-  !
-  !> @brief Commander3 native simulation module. It
-  !! simulates correlated noise and then rewrites
-  !! the original timestreams inside the files.
-  !
-  !> @author Maksym Brilenkov
-  !
-  !> @param[in]
-  !> @param[out]
-  !
-  ! ************************************************
-  subroutine simulate_LFI_tod(self, scan_id, s_tot, handle)
-    use omp_lib
-    implicit none
-    class(comm_LFI_tod), intent(inout) :: self
-    ! Parameter file variables
-    !type(comm_params),                     intent(in)    :: cpar
-    ! Other input/output variables
-    real(sp), allocatable, dimension(:,:), intent(in)    :: s_tot   !< total sky signal
-    integer(i4b),                          intent(in)    :: scan_id !< current PID
-    type(planck_rng),                      intent(inout) :: handle
-    ! Simulation variables
-    real(sp), allocatable, dimension(:,:) :: tod_per_detector !< simulated tods per detector
-    real(sp)                              :: gain   !< detector's gain value
-    real(sp)                              :: sigma0
-    real(sp) :: nu_knee
-    real(sp) :: alpha
-    real(sp) :: samprate
-    real(sp) :: fft_norm
-    integer(i4b)                          :: ntod !< total amount of ODs
-    integer(i4b)                          :: ndet !< total amount of detectors
-    ! HDF5 variables
-    character(len=512) :: mystring, mysubstring !< dummy values for string manipulation
-    integer(i4b)       :: myindex     !< dummy value for string manipulation
-    character(len=512) :: currentHDFFile !< hdf5 file which stores simulation output
-    character(len=6)   :: pidLabel
-    character(len=3)   :: detectorLabel
-    type(hdf_file)     :: hdf5_file   !< hdf5 file to work with
-    integer(i4b)       :: hdf5_error  !< hdf5 error status
-    integer(HID_T)     :: hdf5_file_id !< File identifier
-    integer(HID_T)     :: dset_id     !< Dataset identifier
-    integer(HSIZE_T), dimension(1) :: dims
-    ! Other variables
-    integer(i4b)                          :: i, j, k !< loop variables
-    integer(i4b)       :: mpi_err !< MPI error status
-    integer(i4b)       :: nomp !< Number of threads available
-    integer(i4b)       :: omp_err !< OpenMP error status
-    integer(i4b) :: omp_get_max_threads
-    integer(i4b) :: n, nfft
-    integer*8    :: plan_back
-    real(sp) :: nu
-    real(sp), allocatable, dimension(:,:) :: n_corr
-    real(sp),     allocatable, dimension(:) :: dt
-    complex(spc), allocatable, dimension(:) :: dv
-    character(len=10) :: processor_label   !< to have a nice output to screen
-
-    ! shortcuts
-    ntod = self%scans(scan_id)%ntod
-    ndet = self%ndet
-
-    ! Simulating 1/f noise
-    !write(*,*) "Simulating correlated noise"
-    nfft = 2 * ntod
-    n = nfft / 2 + 1
-    nomp = omp_get_max_threads()
-    call sfftw_init_threads(omp_err)
-    call sfftw_plan_with_nthreads(nomp)
-    ! planning FFTW - in principle we should do both forward and backward FFTW,
-    ! but in this case we can omit forward one and go directly with backward to
-    ! save some time on a whole operation.
-    allocate(dt(nfft), dv(0:n-1))
-    call sfftw_plan_dft_c2r_1d(plan_back, nfft, dv, dt, fftw_estimate + fftw_unaligned)
-    deallocate(dt, dv)
-
-    !$OMP PARALLEL PRIVATE(i, j, k, dt, dv, sigma0, nu, nu_knee, alpha)
-    allocate(dt(nfft), dv(0:n-1), n_corr(ntod, ndet))
-    !$OMP DO SCHEDULE(guided)
-    do j = 1, ndet
-      ! skipping iteration if scan was not accepted
-      if (.not. self%scans(scan_id)%d(j)%accept) cycle
-      ! getting gain for each detector (units, V / K)
-      ! (gain is assumed to be CONSTANT for EACH SCAN)
-      gain   = self%scans(scan_id)%d(j)%gain
-      sigma0 = self%scans(scan_id)%d(j)%sigma0
-      samprate = self%samprate
-      alpha    = self%scans(scan_id)%d(j)%alpha
-      ! knee frequency
-      nu_knee  = self%scans(scan_id)%d(j)%fknee
-      ! used when adding fluctuation terms to Fourier coeffs (depends on Fourier convention)
-      fft_norm = sqrt(1.d0 * nfft)
-      !
-      !dv(0) = dv(0) + fft_norm * sigma0 * cmplx(rand_gauss(handle),rand_gauss(handle)) / sqrt(2.0)
-      dv(0) = fft_norm * sigma0 * cmplx(rand_gauss(handle),rand_gauss(handle)) / sqrt(2.0)
-      do k = 1, (n - 1)
-        nu = k * (samprate / 2) / (n - 1)
-        !dv(k) = sigma0 * cmplx(rand_gauss(handle), rand_gauss(handle)) * sqrt(1 + (nu / nu_knee)**alpha) /sqrt(2          .0)
-        dv(k) = sigma0 * cmplx(rand_gauss(handle), rand_gauss(handle)) * sqrt((nu / nu_knee)**alpha) /sqrt(2.0)
-      end do
-      ! Executing Backward FFT
-      call sfftw_execute_dft_c2r(plan_back, dv, dt)
-      dt = dt / nfft
-      n_corr(:, j) = dt(1:ntod)
-      !write(*,*) "n_corr ", n_corr(:, j)
-    end do
-    !$OMP END DO
-    deallocate(dt, dv)
-    !$OMP END PARALLEL
-
-    call sfftw_destroy_plan(plan_back)
-
-    ! Allocating main simulations' array
-    allocate(tod_per_detector(ntod, ndet))       ! Simulated tod
-
-    ! Main simulation loop
-    do i = 1, ntod
-      do j = 1, ndet
-        ! skipping iteration if scan was not accepted
-        if (.not. self%scans(scan_id)%d(j)%accept) cycle
-        ! getting gain for each detector (units, V / K)
-        ! (gain is assumed to be CONSTANT for EACH SCAN)
-        gain   = self%scans(scan_id)%d(j)%gain
-        !write(*,*) "gain ", gain
-        sigma0 = self%scans(scan_id)%d(j)%sigma0
-        !write(*,*) "sigma0 ", sigma0
-        ! Simulating tods
-        tod_per_detector(i,j) = gain * s_tot(i,j) + n_corr(i, j) + sigma0 * rand_gauss(handle)
-        !tod_per_detector(i,j) = 0
-      end do
-    end do
-
-    !----------------------------------------------------------------------------------
-    ! Saving stuff to hdf file
-    ! Getting the full path and name of the current hdf file to overwrite
-    !----------------------------------------------------------------------------------
-    mystring = trim(self%hdfname(scan_id))
-    mysubstring = 'LFI_0'
-    myindex = index(trim(mystring), trim(mysubstring))
-    currentHDFFile = trim(self%sims_output_dir)//'/'//trim(mystring(myindex:))
-    !write(*,*) "hdf5name "//trim(self%hdfname(scan_id))
-    !write(*,*) "currentHDFFile "//trim(currentHDFFile)
-    ! Converting PID number into string value
-    call int2string(self%scanid(scan_id), pidLabel)
-    call int2string(self%myid, processor_label)
-    write(*,*) "Process: "//trim(processor_label)//" started writing PID: "//trim(pidLabel)//", into:"
-    write(*,*) trim(currentHDFFile)
-    ! For debugging
-    !call MPI_Finalize(mpi_err)
-    !stop
-
-    dims(1) = ntod
-    ! Initialize FORTRAN interface.
-    call h5open_f(hdf5_error)
-    ! Open an existing file - returns hdf5_file_id
-    call  h5fopen_f(currentHDFFile, H5F_ACC_RDWR_F, hdf5_file_id, hdf5_error)
-    do j = 1, ndet
-      detectorLabel = self%label(j)
-      ! Open an existing dataset.
-      call h5dopen_f(hdf5_file_id, trim(pidLabel)//'/'//trim(detectorLabel)//'/'//'tod', dset_id, hdf5_error)
-      ! Write tod data to a dataset
-      call h5dwrite_f(dset_id, H5T_IEEE_F32LE, tod_per_detector(:,j), dims, hdf5_error)
-      ! Close the dataset.
-      call h5dclose_f(dset_id, hdf5_error)
-    end do
-    ! Close the file.
-    call h5fclose_f(hdf5_file_id, hdf5_error)
-    ! Close FORTRAN interface.
-    call h5close_f(hdf5_error)
-
-    !write(*,*) "hdf5_error",  hdf5_error
-    ! freeing memory up
-    deallocate(n_corr, tod_per_detector)
-    write(*,*) "Process:", self%myid, "finished writing PID: "//trim(pidLabel)//"."
-
-    ! lastly, we need to copy an existing filelist.txt into simulation folder
-    ! and change the pointers to new files
-    !if (self%myid == 0) then
-    !  call system("cp "//trim(filelist)//" "//trim(simsdir))
-    !  !mystring = filelist
-    !  !mysubstring = ".txt"
-    !  !myindex = index(trim(mystring), trim(mysubstring))
-    !end if
-
-    ! For debugging
-    !call MPI_Finalize(mpi_err)
-    !stop
-  end subroutine simulate_LFI_tod
 
 end module comm_tod_LFI_mod

--- a/commander3/src/comm_tod_LFI_mod.f90
+++ b/commander3/src/comm_tod_LFI_mod.f90
@@ -31,43 +31,14 @@ module comm_tod_LFI_mod
   use comm_shared_arr_mod
   use spline_1D_mod
   use comm_4D_map_mod
-  use comm_zodi_mod
-  use comm_tod_mapmaking_mod
-  use comm_tod_pointing_mod
-  use comm_tod_gain_mod
-  use comm_tod_bandpass_mod
-  use comm_tod_orbdipole_mod
+  use comm_tod_driver_mod
   use comm_utils
   implicit none
 
   private
   public comm_LFI_tod
 
-  integer(i4b), parameter :: N_test      = 19
-  integer(i4b), parameter :: samp_N      = 1
-  integer(i4b), parameter :: prep_G      = 15
-  integer(i4b), parameter :: samp_G      = 2
-  integer(i4b), parameter :: prep_acal   = 3
-  integer(i4b), parameter :: samp_acal   = 4
-  integer(i4b), parameter :: prep_rcal   = 18
-  integer(i4b), parameter :: samp_rcal   = 19
-  integer(i4b), parameter :: prep_relbp  = 5
-  integer(i4b), parameter :: prep_absbp  = 16
-  integer(i4b), parameter :: samp_bp     = 11
-  integer(i4b), parameter :: samp_sl     = 6
-  integer(i4b), parameter :: samp_N_par  = 7
-  integer(i4b), parameter :: sel_data    = 8
-  integer(i4b), parameter :: bin_map     = 9
-  integer(i4b), parameter :: calc_chisq  = 10
-  integer(i4b), parameter :: output_slist = 12
-  integer(i4b), parameter :: samp_mono   = 13
-  integer(i4b), parameter :: sub_sl      = 14
-  integer(i4b), parameter :: sub_zodi    = 17
-  logical(lgt), dimension(N_test) :: do_oper
-
-
   type, extends(comm_tod) :: comm_LFI_tod
-    class(orbdipole_pointer), allocatable :: orb_dp !orbital dipole calculator
    contains
      procedure     :: process_tod        => process_LFI_tod
      procedure     :: simulate_LFI_tod
@@ -130,9 +101,10 @@ contains
     constructor%nside_param     = cpar%ds_nside(id_abs)
     constructor%compressed_tod  = .false.
     constructor%correct_sl      = .true.
-    constructor%sample_mono     = .false.
     constructor%verbosity       = cpar%verbosity
     constructor%orb_4pi_beam    = .true.
+    constructor%symm_flags      = .true.
+    constructor%chisq_threshold = 7.d0
 
     !----------------------------------------------------------------------------------
     ! Simulation Routine
@@ -237,9 +209,6 @@ contains
        call constructor%mbeam(i)%p%Y()
     end do
 
-    allocate(constructor%orb_dp)
-    constructor%orb_dp%p => comm_orbdipole(constructor, constructor%mbeam)
-
     do i = 1, constructor%ndet
        call read_hdf(h5_file, trim(adjustl(constructor%label(i)))//'/'//'fwhm', constructor%fwhm(i))
        call read_hdf(h5_file, trim(adjustl(constructor%label(i)))//'/'//'elip', constructor%elip(i))
@@ -309,6 +278,10 @@ contains
        constructor%scans(i)%d%baseline = 0.d0
     end do
 
+    ! Allocate orbital dipole object
+    allocate(constructor%orb_dp)
+    constructor%orb_dp => comm_orbdipole(constructor%mbeam)
+
   end function constructor
 
   !**************************************************
@@ -325,848 +298,209 @@ contains
     class(comm_map),                          intent(inout) :: map_out      ! Combined output map
     class(comm_map),                          intent(inout) :: rms_out      ! Combined output rms
 
-    integer(i4b) :: i, j, k, l, start_chunk, end_chunk, chunk_size, ntod, ndet
-    integer(i4b) :: nside, npix, nmaps, naccept, ntot, ext(2), nscan_tot, nhorn
-    integer(i4b) :: ierr, main_iter, n_main_iter, ndelta, ncol, n_A, nout=1
-    real(dp)     :: t1, t2, t3, t4, t5, t6, t7, t8, t9, t10, chisq_threshold
-    real(dp)     :: t_tot(23)
-    real(sp)     :: inv_gain
-    real(sp),     allocatable, dimension(:,:)     :: n_corr, s_sl, s_sky, s_orb, mask, mask2, mask_lowres, s_bp
-    real(sp),     allocatable, dimension(:,:)     :: s_mono, s_buf, s_tot, s_zodi
-    real(sp),     allocatable, dimension(:,:)     :: s_invN
-    real(sp),     allocatable, dimension(:,:,:)   :: s_sky_prop, s_bp_prop
-    real(sp),     allocatable, dimension(:,:,:)   :: d_calib
-    real(dp),     allocatable, dimension(:)       :: A_abscal, b_abscal
-    real(dp),     allocatable, dimension(:,:)     :: chisq_S, m_buf
-    real(dp),     allocatable, dimension(:,:)     :: A_map, dipole_mod
-    real(dp),     allocatable, dimension(:,:,:)   :: b_map, b_mono, sys_mono
-    integer(i4b), allocatable, dimension(:,:,:)   :: pix, psi 
-    integer(i4b), allocatable, dimension(:,:)     :: flag
-    logical(lgt)       :: correct_sl
-    character(len=512) :: prefix, postfix, prefix4D, filename
-    character(len=2048) :: Sfilename
-    character(len=4)   :: ctext, myid_text
-    character(len=6)   :: samptext, scantext
+    real(dp)            :: t1, t2
+    integer(i4b)        :: i, j, k, l, ierr, ndelta, nside, npix, nmaps
+    logical(lgt)        :: select_data, sample_abs_bandpass, sample_rel_bandpass, output_scanlist
+    type(comm_binmap)   :: binmap
+    type(comm_scandata) :: sd
+    character(len=4)    :: ctext, myid_text
+    character(len=6)    :: samptext, scantext
+    character(len=512)  :: prefix, postfix, prefix4D, filename
     character(len=512), allocatable, dimension(:) :: slist
-    type(shared_1d_int) :: sprocmask, sprocmask2
-    real(sp),           allocatable, dimension(:,:,:,:) :: map_sky
-    type(shared_2d_dp) :: sA_map
-    type(shared_3d_dp) :: sb_map, sb_mono
-    class(comm_map), pointer :: condmap
-    class(map_ptr), allocatable, dimension(:) :: outmaps
+    real(sp), allocatable, dimension(:)       :: procmask, procmask2
+    real(sp), allocatable, dimension(:,:)     :: s_buf
+    real(sp), allocatable, dimension(:,:,:)   :: d_calib
+    real(sp), allocatable, dimension(:,:,:,:) :: map_sky
+    real(dp), allocatable, dimension(:,:)     :: chisq_S, m_buf
 
-    !if (iter > 1) self%first_call = .false.
     call int2string(iter, ctext)
     call update_status(status, "tod_start"//ctext)
 
-    t_tot   = 0.d0
-    call wall_time(t5)
+    ! Toggle optional operations
+    sample_rel_bandpass   = .true.                 
+    sample_abs_bandpass   = .false.                ! don't sample absolute bandpasses...
+    select_data           = self%first_call        ! only perform data selection the first time
+    output_scanlist       = mod(iter-1,10) == 0    ! only output scanlist every 10th iteration
 
-
-    ! Set up full-sky map structures
-    call wall_time(t1)
-    if (self%output_aux_maps <= 0) then
-       self%output_n_maps = 3
-    else
-       if (mod(iter-1,self%output_aux_maps) == 0) then
-          self%output_n_maps = 7
-       else
-          self%output_n_maps = 3
-       end if
-    end if
-
-    correct_sl      = .true.
-    chisq_threshold = 7.d0
-    n_main_iter     = 4
-    chisq_threshold = 9.d0  !3000.d0
-    !this ^ should be 7.d0, is currently 2000 to debug sidelobes
-    ndet            = self%ndet
-    nhorn           = self%nhorn
+    ! Initialize local variables
     ndelta          = size(delta,3)
     nside           = map_out%info%nside
     nmaps           = map_out%info%nmaps
     npix            = 12*nside**2
-    nscan_tot       = self%nscan_tot
-    chunk_size      = npix/self%numprocs_shared
-    if (chunk_size*self%numprocs_shared /= npix) chunk_size = chunk_size+1
-    allocate(A_abscal(self%ndet), b_abscal(self%ndet))
-    allocate(map_sky(nmaps,self%nobs,0:ndet,ndelta))
-    allocate(chisq_S(ndet,ndelta))
-    allocate(slist(self%nscan))
-    allocate(dipole_mod(nscan_tot, ndet))
-    slist   = ''
+    self%output_n_maps = 3
+    if (self%output_aux_maps > 0) then
+       if (mod(iter-1,self%output_aux_maps) == 0) self%output_n_maps = 7
+    end if
 
     call int2string(chain, ctext)
     call int2string(iter, samptext)
+    call int2string(self%myid, myid_text)
     prefix = trim(chaindir) // '/tod_' // trim(self%freq) // '_'
     postfix = '_c' // ctext // '_k' // samptext // '.fits'
 
-    if (self%myid == 0) then
-       do k = 1, ndelta
-          write(*,*) 'delta in =', real(delta(:,1,k),sp)
-       end do
-    end if
+    ! Distribute maps
+    allocate(map_sky(nmaps,self%nobs,0:self%ndet,ndelta))
+    call distribute_sky_maps(self, map_in, 1.e-6, map_sky) ! uK to K
 
-    if (.false.) then
-       do i = 1, self%ndet
-          filename = trim(chaindir) // '/BP_fg_' // trim(self%label(i)) // '_v1.fits'
-          call map_in(i,1)%p%writeFITS(filename)
-          filename = trim(chaindir) // '/BP_fg_' // trim(self%label(i)) // '_v2.fits'
-          call map_in(i,2)%p%writeFITS(filename)
-       end do
-       call mpi_finalize(ierr)
-       stop
-!!$       deallocate(A_abscal, chisq_S, slist)
-!!$       return
-    end if
-
-    ! Distribute fullsky maps
-    allocate(m_buf(0:npix-1,nmaps))
-    do j = 1, ndelta
-       do i = 1, self%ndet
-          map_in(i,j)%p%map = 1d-6 * map_in(i,j)%p%map ! uK to K
-          call map_in(i,j)%p%bcast_fullsky_map(m_buf)
-          do k = 1, self%nobs
-             map_sky(:,k,i,j) = m_buf(self%ind2pix(k),:) ! uK to K
-          end do
-       end do
-       do k = 1, self%nobs
-          do l = 1, nmaps
-             map_sky(l,k,0,j) = sum(map_sky(l,k,1:ndet,j))/ndet
-          end do
-       end do
-    end do
+    ! Distribute processing masks
+    allocate(m_buf(0:npix-1,nmaps), procmask(0:npix-1), procmask2(0:npix-1))
+    call self%procmask%bcast_fullsky_map(m_buf);  procmask  = m_buf(:,1)
+    call self%procmask2%bcast_fullsky_map(m_buf); procmask2 = m_buf(:,1)
     deallocate(m_buf)
 
-    ! Set up shared processing mask
-    call init_shared_1d_int(self%myid_shared, self%comm_shared, &
-         & self%myid_inter, self%comm_inter, [npix], sprocmask)
-    call sync_shared_1d_int_map(sprocmask, self%procmask%info%pix, &
-         & nint(self%procmask%map(:,1)))
-    call init_shared_1d_int(self%myid_shared, self%comm_shared, &
-         & self%myid_inter, self%comm_inter, [npix], sprocmask2)
-    call sync_shared_1d_int_map(sprocmask2, self%procmask2%info%pix, &
-         & nint(self%procmask2%map(:,1)))
-    call wall_time(t2); t_tot(9) = t2-t1
-
-
-    ! Compute far sidelobe Conviqt structures
-    call wall_time(t1)
-    if (self%myid == 0) write(*,*) 'Precomputing sidelobe convolved sky'
-    do i = 1, self%ndet
-       if (.not. correct_sl) exit
-
-       !TODO: figure out why this is rotated
-       call map_in(i,1)%p%YtW()  ! Compute sky a_lms
-       self%slconv(i)%p => comm_conviqt(self%myid_shared, self%comm_shared, &
-            & self%myid_inter, self%comm_inter, self%slbeam(i)%p%info%nside, &
-            & 100, 3, 100, self%slbeam(i)%p, map_in(i,1)%p, 2)
-!       write(*,*) i, 'b', sum(abs(self%slconv(i)%p%c%a))
-    end do
-    call wall_time(t2); t_tot(13) = t2-t1
+    ! Precompute far sidelobe Conviqt structures
+    if (.not. self%correct_sl) then
+       if (self%myid == 0) write(*,*) 'Precomputing sidelobe convolved sky'
+       do i = 1, self%ndet
+          !TODO: figure out why this is rotated
+          call map_in(i,1)%p%YtW()  ! Compute sky a_lms
+          self%slconv(i)%p => comm_conviqt(self%myid_shared, self%comm_shared, &
+               & self%myid_inter, self%comm_inter, self%slbeam(i)%p%info%nside, &
+               & 100, 3, 100, self%slbeam(i)%p, map_in(i,1)%p, 2)
+       end do
+    end if
 
     call update_status(status, "tod_init")
 
+    !------------------------------------
+    ! Perform main sampling steps
+    !------------------------------------
 
+    ! Sample gain components in separate TOD loops; marginal with respect to n_corr
+    call sample_calibration(self, 'abscal', handle, map_sky, procmask, procmask2)
+    call sample_calibration(self, 'relcal', handle, map_sky, procmask, procmask2)
+    call sample_calibration(self, 'deltaG', handle, map_sky, procmask, procmask2)
 
-    ! Compute output map and rms
-    call wall_time(t3)
-    do_oper             = .true.
-    do main_iter = 1, n_main_iter
+    ! Prepare intermediate data structures
+    call binmap%init(self, .true., sample_rel_bandpass)
+    if (sample_abs_bandpass) then
+       allocate(chisq_S(self%ndet,size(delta,3)))
+       chisq_S = 0.d0
+    end if
+    if (output_scanlist) then
+       allocate(slist(self%nscan))
+       slist   = ''
+    end if
 
-       call wall_time(t7)
-       call update_status(status, "tod_istart")
+    ! Perform loop over scans
+    do i = 1, self%nscan
+       
+       ! Skip scan if no accepted data
+       if (.not. any(self%scans(i)%d%accept)) cycle
+       call wall_time(t1)
 
-       if (self%myid == 0) write(*,*) '  Performing main iteration = ', main_iter
+       ! Prepare data
+       if (sample_rel_bandpass) then
+          call sd%init_singlehorn(self, i, map_sky, procmask, procmask2, init_s_bp=.true., init_s_bp_prop=.true.)
+       else if (sample_abs_bandpass) then
+          call sd%init_singlehorn(self, i, map_sky, procmask, procmask2, init_s_bp=.true., init_s_sky_prop=.true.)
+       else
+          call sd%init_singlehorn(self, i, map_sky, procmask, procmask2, init_s_bp=.true.)
+       end if
+       allocate(s_buf(sd%ntod,sd%ndet))
 
-       ! Select operations for current iteration
-       do_oper(samp_acal)    = (main_iter == n_main_iter-3) !.and. .not. self%first_call
-       do_oper(samp_rcal)    = (main_iter == n_main_iter-2) !.and. .not. self%first_call
-       do_oper(samp_G)       = (main_iter == n_main_iter-1) !.and. .not. self%first_call
-       do_oper(samp_N)       = (main_iter >= n_main_iter-0)
-       do_oper(samp_N_par)   = do_oper(samp_N)
-       do_oper(prep_relbp)   = ndelta > 1 .and. (main_iter == n_main_iter-0) .and. .not. self%first_call !.and. mod(iter,2) == 0
-       do_oper(prep_absbp)   = .false. !ndelta > 1 .and. (main_iter == n_main_iter-0) .and. .not. self%first_call .and. mod(iter,2) == 1
-       do_oper(samp_bp)      = ndelta > 1 .and. (main_iter == n_main_iter-0) .and. .not. self%first_call
-       do_oper(samp_mono)    = .false. !do_oper(bin_map)             !.and. .not. self%first_call
-       do_oper(bin_map)      = (main_iter == n_main_iter  )
-       do_oper(sel_data)     = .false. !(main_iter == n_main_iter  ) .and.       self%first_call
-       do_oper(calc_chisq)   = (main_iter == n_main_iter  )
-       do_oper(sub_sl)       = correct_sl
-       do_oper(sub_zodi)     = self%subtract_zodi
-       do_oper(output_slist) = mod(iter, 1) == 0
-
-       dipole_mod = 0
-
-       ! Perform pre-loop operations
-       if (do_oper(bin_map) .or. do_oper(prep_relbp)) then
-          if (do_oper(prep_relbp)) then
-             ncol = nmaps + ndet - 1
-             n_A  = nmaps*(nmaps+1)/2 + 4*(ndet-1)
-             nout = self%output_n_maps + ndelta - 1
-          else
-             ncol = nmaps
-             n_A  = nmaps*(nmaps+1)/2
-             nout = self%output_n_maps
-          end if
-          allocate(outmaps(nout))
-          do i = 1, nout
-             outmaps(i)%p => comm_map(map_out%info)
-          end do
-          if (allocated(A_map)) deallocate(A_map, b_map)
-          allocate(A_map(n_A,self%nobs), b_map(nout,ncol,self%nobs))
-          A_map = 0.d0; b_map = 0.d0
-          if (sA_map%init) call dealloc_shared_2d_dp(sA_map)
-          call init_shared_2d_dp(self%myid_shared, self%comm_shared, &
-               & self%myid_inter, self%comm_inter, [n_A,npix], sA_map)
-          call mpi_win_fence(0, sA_map%win, ierr)
-          if (sA_map%myid_shared == 0) sA_map%a = 0.d0
-          call mpi_win_fence(0, sA_map%win, ierr)
-          if (sb_map%init) call dealloc_shared_3d_dp(sb_map)
-          call init_shared_3d_dp(self%myid_shared, self%comm_shared, &
-               & self%myid_inter, self%comm_inter, [nout,ncol,npix], sb_map)
-          call mpi_win_fence(0, sb_map%win, ierr)
-          if (sb_map%myid_shared == 0) sb_map%a = 0.d0
-          call mpi_win_fence(0, sb_map%win, ierr)
+       ! Calling Simulation Routine
+       if (self%enable_tod_simulations) then
+          call self%simulate_LFI_tod(i, sd%s_tot, handle)
+          call sd%dealloc
+          cycle
        end if
 
-       if (do_oper(samp_mono)) then
-          allocate(b_mono(nmaps,self%nobs,ndet), sys_mono(nmaps,nmaps+ndet,0:self%info%np-1))
-          b_mono = 0.d0
-          call init_shared_3d_dp(self%myid_shared, self%comm_shared, &
-               & self%myid_inter, self%comm_inter, [nmaps,npix,ndet], sb_mono)
-          call mpi_win_fence(0, sb_mono%win, ierr)
-          if (sb_map%myid_shared == 0) sb_mono%a = 0.d0
-          call mpi_win_fence(0, sb_mono%win, ierr)
-       end if
+       ! Sample correlated noise
+       call sample_n_corr(self, handle, i, sd%mask, sd%s_tot, sd%n_corr, sd%pix(:,:,1), dospike=.true.)
 
-       if (do_oper(sel_data)) then
-          naccept = 0; ntot    = 0
-       end if
+       ! Compute noise spectrum parameters
+       call sample_noise_psd(self, handle, i, sd%mask, sd%s_tot, sd%n_corr)
 
-       if (do_oper(samp_acal) .or. do_oper(samp_rcal)) then
-          A_abscal = 0.d0; b_abscal = 0.d0
-       end if
-
-       if (do_oper(prep_absbp)) then
-          chisq_S = 0.d0
-       end if
-
-       call wall_time(t8); t_tot(19) = t_tot(19) + t8-t7
-
-      !  print *, "Total number of scans:", self%nscan
-      !  print *, "Total number of tot scans:", self%nscan_tot
-       ! Perform main analysis loop
-       do i = 1, self%nscan
-
-          !call update_status(status, "tod_loop1")
-          call wall_time(t7)
-
-          if (.not. any(self%scans(i)%d%accept)) cycle
-
-          ! Short-cuts to local variables
-          call wall_time(t1)
-          ntod = self%scans(i)%ntod
-          ndet = self%ndet
-
-          ! Set up local data structure for current scan
-          allocate(n_corr(ntod, ndet))                 ! Correlated noise in V
-          allocate(s_sl(ntod, ndet))                   ! Sidelobe in uKcmb
-          allocate(s_sky(ntod, ndet))                  ! Sky signal in uKcmb
-          allocate(s_sky_prop(ntod, ndet,2:ndelta))    ! Sky signal in uKcmb
-          allocate(s_bp(ntod, ndet))                   ! Signal minus mean
-          allocate(s_bp_prop(ntod, ndet, 2:ndelta))    ! Signal minus mean
-          allocate(s_orb(ntod, ndet))                  ! Orbital dipole in uKcmb
-          if (do_oper(samp_mono)) allocate(s_mono(ntod, ndet))                 ! Monopole correction in uKcmb
-          allocate(s_buf(ntod, ndet))                  ! Buffer
-          allocate(s_tot(ntod, ndet))                  ! Sum of all sky compnents
-          if (do_oper(sub_zodi)) allocate(s_zodi(ntod, ndet))                 ! Zodical light
-          allocate(mask(ntod, ndet))                   ! Processing mask in time
-          allocate(mask2(ntod, ndet))                  ! Processing mask in time
-          allocate(pix(ntod, ndet, nhorn))                    ! Decompressed pointing
-          allocate(psi(ntod, ndet, nhorn))                    ! Decompressed pol angle
-          allocate(flag(ntod, ndet))                   ! Decompressed flags
-
-          ! Initializing arrays to zero
-          call wall_time(t2); t_tot(18) = t_tot(18) + t2-t1
-
-          ! --------------------
-          ! Analyze current scan
-          ! --------------------
-
-          ! Decompress pointing, psi and flags for current scan
-          call wall_time(t1)
-          do j = 1, ndet
-             if (.not. self%scans(i)%d(j)%accept) cycle
-             call self%decompress_pointing_and_flags(i, j, pix(:,j,:), &
-                  & psi(:,j,:), flag(:,j))
-          end do
-          call self%symmetrize_flags(flag)
-          !call validate_psi(self%scanid(i), psi)
-          call wall_time(t2); t_tot(11) = t_tot(11) + t2-t1
-          !call update_status(status, "tod_decomp")
-
-          ! Construct sky signal template
-          call wall_time(t1)
-          if (do_oper(bin_map) .or. do_oper(prep_relbp)) then
-             call project_sky(self, map_sky(:,:,:,1), pix(:,:,1), psi(:,:,1), flag, &
-                  & sprocmask%a, i, s_sky, mask, s_bp=s_bp)
-          else
-             call project_sky(self, map_sky(:,:,:,1), pix(:,:,1), psi(:,:,1), flag, &
-                  & sprocmask%a, i, s_sky, mask)
-          end if
-          if (do_oper(prep_relbp)) then
-             do j = 2, ndelta
-                call project_sky(self, map_sky(:,:,:,j), pix(:,:,1), psi(:,:,1), flag, &
-                     & sprocmask2%a, i, s_sky_prop(:,:,j), mask2, s_bp=s_bp_prop(:,:,j))
-             end do
-          else if (do_oper(prep_absbp)) then
-             do j = 2, ndelta
-                call project_sky(self, map_sky(:,:,:,j), pix(:,:,1), psi(:,:,1), flag, &
-                     & sprocmask2%a, i, s_sky_prop(:,:,j), mask2)
-             end do
-          end if
-          if (main_iter == 1 .and. self%first_call) then
-             do j = 1, ndet
-                if (all(mask(:,j) == 0)) self%scans(i)%d(j)%accept = .false.
-                if (self%scans(i)%d(j)%sigma0 <= 0.d0) self%scans(i)%d(j)%accept = .false.
-             end do
-          end if
-          do j = 1, ndet
-             if (.not. self%scans(i)%d(j)%accept) cycle
-             if (self%scans(i)%d(j)%sigma0 <= 0) write(*,*) main_iter, self%scanid(i), j, self%scans(i)%d(j)%sigma0
-          end do
-          call wall_time(t2); t_tot(1) = t_tot(1) + t2-t1
-          !call update_status(status, "tod_project")
-
-          ! Construct orbital dipole template
-          call wall_time(t1)
-          call self%orb_dp%p%compute_orbital_dipole_4pi(i, pix(:,:,1), psi(:,:,1), s_orb)
-          call wall_time(t2); t_tot(2) = t_tot(2) + t2-t1
-          !call update_status(status, "tod_orb")
-
-         !  call wall_time(t9)
-          ! Construct zodical light template
-          if (do_oper(sub_zodi)) then
-             call compute_zodi_template(self%nside, pix(:,:,1), self%scans(i)%satpos, [30.d9, 30.d9, 30.d9, 30.d9], s_zodi)
-          end if
-         !  call wall_time(t10)
-         !  print *, "Zodi template took :", t10-t9, "sec"
-
-          ! Construct sidelobe template
-          call wall_time(t1)
-          if (do_oper(sub_sl)) then
-             do j = 1, ndet
-                if (.not. self%scans(i)%d(j)%accept) cycle
-                call self%construct_sl_template(self%slconv(j)%p, &
-                     & pix(:,j,1), psi(:,j,1), s_sl(:,j), self%polang(j))
-                s_sl(:,j) = 2 * s_sl(:,j) ! Scaling by a factor of 2, by comparison with LevelS. Should be understood
-             end do
-          else
-             do j = 1, ndet
-                if (.not. self%scans(i)%d(j)%accept) cycle
-                s_sl(:,j) = 0.
-             end do
-          end if
-          call wall_time(t2); t_tot(12) = t_tot(12) + t2-t1
-
-          ! Construct monopole correction template
-          call wall_time(t1)
-          if (do_oper(samp_mono)) then
-             do j = 1, ndet
-                if (.not. self%scans(i)%d(j)%accept) cycle
-                !s_mono(:,j) = self%mono(j)
-                s_mono(:,j) = 0.d0 ! Disabled for now
-             end do
-          end if
-          do j = 1, ndet
-             if (.not. self%scans(i)%d(j)%accept) cycle
-             s_tot(:,j) = s_sky(:,j) + s_sl(:,j) + s_orb(:,j)
-             if (do_oper(samp_mono)) s_tot(:,j) = s_tot(:,j) + s_mono(:,j)
-          end do
-          call wall_time(t2); t_tot(1) = t_tot(1) + t2-t1
-
-          ! Precompute filtered signal for calibration
-          if (do_oper(samp_G) .or. do_oper(samp_rcal) .or. do_oper(samp_acal)) then
-             call self%downsample_tod(s_orb(:,1), ext)
-             allocate(     s_invN(ext(1):ext(2), ndet))      ! s * invN
-             allocate(mask_lowres(ext(1):ext(2), ndet))
-             do j = 1, ndet
-                if (.not. self%scans(i)%d(j)%accept) cycle
-                call self%downsample_tod(mask(:,j), ext, &
-                     & mask_lowres(:,j), threshold=0.9)!, mask(:,j))  
-                if (do_oper(samp_G) .or. do_oper(samp_rcal) .or. .not. self%orb_abscal) then
-                   s_buf(:,j) = s_tot(:,j)
-                   call fill_all_masked(s_buf(:,j), mask(:,j), ntod, .false., real(self%scans(i)%d(j)%sigma0, sp), handle, self%scans(i)%chunk_num)
-                   call self%downsample_tod(s_buf(:,j), ext, &
-                        & s_invN(:,j))!, mask(:,j))
-                else
-                   call self%downsample_tod(s_orb(:,j), ext, &
-                        & s_invN(:,j))!, mask(:,j))
-                end if
-             end do
-             call multiply_inv_N(self, i, s_invN,   sampfreq=self%samprate_lowres, pow=0.5d0)
-          end if
-
-          ! Prepare for absolute calibration
-          if (do_oper(samp_acal) .or. do_oper(samp_rcal)) then
-             call wall_time(t1)
-             do j = 1, ndet
-                if (.not. self%scans(i)%d(j)%accept) cycle
-
-                if (do_oper(samp_acal)) then
-                   if (self%orb_abscal) then
-                      s_buf(:, j) = real(self%gain0(0),sp) * (s_tot(:, j) - s_orb(:, j)) + &
-                           & real(self%gain0(j) + self%scans(i)%d(j)%dgain,sp) * s_tot(:, j)
-                   else
-                      s_buf(:, j) = real(self%gain0(j) + self%scans(i)%d(j)%dgain,sp) * s_tot(:, j)
-                   end if
-                else
-!                   s_buf(:,j) =  s_tot(:,j) - s_orb(:,j) !s_sky(:,j) + s_sl(:,j) + s_mono(:,j)
-                   s_buf(:,j) = real(self%gain0(0) + self%scans(i)%d(j)%dgain,sp) * s_tot(:, j)
-                end if
-             end do
-             call accumulate_abscal(self, i, mask, s_buf, s_invN, s_invN, A_abscal, b_abscal, handle, out=do_oper(samp_acal), mask_lowres=mask_lowres)
-
-             if (.false.) then
-                call int2string(self%scanid(i), scantext)
-                open(78,file='tod_'//trim(self%label(j))//'_pid'//scantext//'_k'//samptext//'.dat', recl=1024)
-                write(78,*) "# Sample     Data (V)    Res (V)    s_sub (K)   s_orb (K)   mask"
-                do k = 1, ntod, 60
-                   write(78,*) k, mean(1.d0*self%scans(i)%d(j)%tod(k:k+59)), mean(1.d0*self%scans(i)%d(j)%tod(k:k+59) - &
-                        & self%scans(i)%d(j)%gain*s_buf(k:k+59,j)), mean(1.d0*s_orb(k:k+59,j)),  mean(1.d0*s_buf(k:k+59,j)),  minval(mask(k:k+59,j))
-                end do
-                close(78)
-             end if
-             call wall_time(t2); t_tot(14) = t_tot(14) + t2-t1
-          end if
-
-          ! Fit gain
-          if (do_oper(samp_G)) then
-             call wall_time(t1)
-             call calculate_gain_mean_std_per_scan(self, i, s_invN, mask, s_invN, s_tot, handle, mask_lowres=mask_lowres)
-             call wall_time(t2); t_tot(4) = t_tot(4) + t2-t1
-          end if
-
-          ! Fit correlated noise
-          if (do_oper(samp_N)) then
-             call wall_time(t1)
-             do j = 1, ndet
-                if (.not. self%scans(i)%d(j)%accept) cycle
-                if (do_oper(samp_mono)) then
-                   s_buf(:,j) = s_tot(:,j)-s_mono(:,j)
-                else
-                   s_buf(:,j) = s_tot(:,j)
-                end if
-             end do
-             call sample_n_corr(self, handle, i, mask, s_buf, n_corr, pix(:,:,1), dospike=.true.)
-!!$             do j = 1, ndet
-!!$                n_corr(:,j) = sum(n_corr(:,j))/ size(n_corr,1)
-!!$             end do
-             call wall_time(t2); t_tot(3) = t_tot(3) + t2-t1
-          else
-             n_corr = 0.
-          end if
-
-          ! Compute noise spectrum
-          if (do_oper(samp_N_par)) then
-             call wall_time(t1)
-             call sample_noise_psd(self, handle, i, mask, s_tot, n_corr)
-             call wall_time(t2); t_tot(6) = t_tot(6) + t2-t1
-          end if
-          ! Compute chisquare
-          if (do_oper(calc_chisq)) then
-             call wall_time(t1)
-             do j = 1, ndet
-                if (.not. self%scans(i)%d(j)%accept) cycle
-                s_buf(:,j) =  s_sl(:,j) + s_orb(:,j)
-                if (do_oper(samp_mono)) s_buf(:,j) =  s_buf(:,j) + s_mono(:,j)
-                call self%compute_chisq(i, j, mask(:,j), s_sky(:,j), &
-                     & s_buf(:,j), n_corr(:,j))
-             end do
-             call wall_time(t2); t_tot(7) = t_tot(7) + t2-t1
-          end if
-
-          ! Select data
-          if (do_oper(sel_data)) then
-             call wall_time(t1)
-             do j = 1, ndet
-                ntot= ntot + 1
-                if (.not. self%scans(i)%d(j)%accept) cycle
-                if (count(iand(flag(:,j),self%flag0) .ne. 0) > 0.1*ntod) then
-                   self%scans(i)%d(j)%accept = .false.
-                else if (abs(self%scans(i)%d(j)%chisq) > chisq_threshold .or. &
-                & isNaN(self%scans(i)%d(j)%chisq)) then
-                   write(*,fmt='(a,i8,i5,a,f12.1)') 'Reject scan, det = ', &
-                        & self%scanid(i), j, ', chisq = ', &
-                        & self%scans(i)%d(j)%chisq
-                   self%scans(i)%d(j)%accept = .false.
-                   cycle
-                else
-                   naccept = naccept + 1
-                end if
-             end do
-             if (any(.not. self%scans(i)%d%accept)) self%scans(i)%d%accept = .false.
-             do j = 1, ndet
-                if (.not. self%scans(i)%d(j)%accept) then
-                   self%scans(i)%d(self%partner(j))%accept = .false.
-                end if
-             end do
-             call wall_time(t2); t_tot(15) = t_tot(15) + t2-t1
-          end if
-
-          ! Compute chisquare for bandpass fit
-          if (do_oper(prep_absbp)) then
-             call wall_time(t1)
-             do j = 1, ndet
-                if (.not. self%scans(i)%d(j)%accept) cycle
-                s_buf(:,j) =  s_sl(:,j) + s_orb(:,j)
-                if (do_oper(samp_mono)) s_buf(:,j) =  s_buf(:,j) + s_mono(:,j)
-                call self%compute_chisq(i, j, mask2(:,j), s_sky(:,j), &
-                     & s_buf(:,j), n_corr(:,j), absbp=.true.)
-                chisq_S(j,1) = chisq_S(j,1) + self%scans(i)%d(j)%chisq_prop
-                do k = 2, ndelta
-                   call self%compute_chisq(i, j, mask2(:,j), s_sky_prop(:,j,k), &
-                        & s_buf(:,j), n_corr(:,j), absbp=.true.)
-                   chisq_S(j,k) = chisq_S(j,k) + self%scans(i)%d(j)%chisq_prop
-                end do
-             end do
-             call wall_time(t2); t_tot(7) = t_tot(7) + t2-t1
-          end if
-
-
-          ! Compute binned map
-          if (do_oper(bin_map)) then
-             call wall_time(t1)
-             allocate(d_calib(nout,ntod, ndet))
-             do j = 1, ndet
-                if (.not. self%scans(i)%d(j)%accept) cycle
-                inv_gain = 1.0 / real(self%scans(i)%d(j)%gain,sp)
-                d_calib(1,:,j) = (self%scans(i)%d(j)%tod - n_corr(:,j)) * &
-                     & inv_gain - s_tot(:,j) + s_sky(:,j) - s_bp(:,j)
-                if (do_oper(bin_map) .and. nout > 1) d_calib(2,:,j) = d_calib(1,:,j) - s_sky(:,j) + s_bp(:,j) ! Residual
-                if (do_oper(bin_map) .and. nout > 2) d_calib(3,:,j) = (n_corr(:,j) - sum(n_corr(:,j)/ntod)) * inv_gain
-                if (do_oper(bin_map) .and. nout > 3) d_calib(4,:,j) = s_bp(:,j)
-                if (do_oper(bin_map) .and. nout > 4) then
-                   if (do_oper(samp_mono)) then
-                      d_calib(5,:,j) = s_mono(:,j)
-                   else
-                      d_calib(5,:,j) = 0.d0
-                   end if
-                end if
-                if (do_oper(bin_map) .and. nout > 5) d_calib(6,:,j) = s_orb(:,j)
-                if (do_oper(bin_map) .and. nout > 6) d_calib(7,:,j) = s_sl(:,j)
-                if (do_oper(bin_map) .and. nout > 7 .and. do_oper(sub_zodi)) d_calib(8,:,j) = s_zodi(:,j)
-
-                if (do_oper(prep_relbp)) then
-                   do k = 2, ndelta
-                      d_calib(self%output_n_maps+k-1,:,j) = d_calib(1,:,j) + s_bp(:,j) - s_bp_prop(:,j,k)
-                   end do
-                end if
-             end do
-
-             if (do_oper(bin_map) .and. self%output_4D_map > 0 .and. mod(iter-1,self%output_4D_map) == 0) then
-
-                ! Output 4D map; note that psi is zero-base in 4D maps, and one-base in Commander
-                call int2string(self%myid, myid_text)
-                call output_4D_maps_hdf(trim(chaindir) // '/tod_4D_chain'//ctext//'_proc' // myid_text // '.h5', &
-                     & samptext, self%scanid(i), self%nside, self%npsi, &
-                     & self%label, self%horn_id, real(self%polang*180/pi,sp), &
-                     & real(self%scans(i)%d%sigma0/self%scans(i)%d%gain,sp), &
-                     & pix(:,:,1), psi(:,:,1)-1, d_calib(1,:,:), iand(flag,self%flag0), &
-                     & self%scans(i)%d(:)%accept)
-!                prefix4D = "!"// trim(chaindir) // '/.tod_' // trim(self%freq) // '_' // '4D_pid' // scantext
-!                call output_4D_maps(prefix4D, postfix, self%scanid(i), self%nside, self%npsi, &
-!                     & self%label, self%horn_id, real(self%polang*180/pi,sp), &
-!                     & real(self%scans(i)%d%sigma0/self%scans(i)%d%gain,sp), &
-!                     & pix, psi-1, d_calib(1,:,:), iand(flag,self%flag0), &
-!                     & self%scans(i)%d(:)%accept)
-             end if
-
-
-             call wall_time(t2); t_tot(5) = t_tot(5) + t2-t1
-
-             if (.false. .and. do_oper(bin_map)) then
-                call int2string(self%scanid(i), scantext)
-                do k = 1, self%ndet
-                   open(78,file='tod_'//trim(self%label(k))//'_pid'//scantext//'.dat', recl=1024)
-                   write(78,*) "# Sample     Data (V)     Mask    cal_TOD (K)   res (K)"// &
-                        & "   n_corr (K)   s_corr (K)   s_mono (K)   s_orb  (K)   s_sl (K)"
-                   do j = 1, ntod
-                      write(78,*) j, self%scans(i)%d(k)%tod(j), mask(j,1), d_calib(:,j,k)
-                   end do
-                   close(78)
-                end do
-             end if
-
-
-             call wall_time(t1)
-
-             if (do_oper(samp_mono)) then
-                call bin_TOD(self, d_calib, pix(:,:,1), &
-                     & psi(:,:,1), flag, A_map, b_map, i, do_oper(prep_relbp), b_mono=b_mono)
-             else
-                call bin_TOD(self, d_calib, pix(:,:,1), &
-                     & psi(:,:,1), flag, A_map, b_map, i, do_oper(prep_relbp))
-             end if
-             deallocate(d_calib)
-             call wall_time(t2); t_tot(8) = t_tot(8) + t2-t1
-          end if
-
-          do j = 1, ndet
-             if (.not. self%scans(i)%d(j)%accept) cycle
-             dipole_mod(self%scanid(i), j) = masked_variance(s_sky(:, j), mask(:, j))
-          end do
-
-          !----------------------------------------------------------------------------------
-          ! Calling Simulation Routine
-          !write(*,*) "Debug Message before simulation routine."
-          if (self%enable_tod_simulations) then !.and. (main_iter == 1)) then
-            call wall_time(t1)
-            call self%simulate_LFI_tod(i, s_tot, handle)
-            call wall_time(t2); t_tot(23) = t_tot(23) + t2-t1
-          end if
-          !----------------------------------------------------------------------------------
-          ! Clean up
-          call wall_time(t1)
-          deallocate(n_corr, s_sl, s_sky, s_orb, s_tot, s_buf)
-          deallocate(s_bp, s_sky_prop, s_bp_prop)
-          deallocate(mask, mask2, pix, psi, flag)
-          if (allocated(s_invN)) deallocate(s_invN)
-          if (allocated(mask_lowres)) deallocate(mask_lowres)
-          if (do_oper(sub_zodi)) deallocate(s_zodi)
-          if (do_oper(samp_mono)) deallocate(s_mono)
-          call wall_time(t2); t_tot(18) = t_tot(18) + t2-t1
-
-          call wall_time(t8); t_tot(19) = t_tot(19) + t8-t7
-
-          if (do_oper(output_slist)) then
-             self%scans(i)%proctime   = self%scans(i)%proctime   + t8-t7
-             self%scans(i)%n_proctime = self%scans(i)%n_proctime + 1
-             if (main_iter == n_main_iter) then
-                write(slist(i),*) self%scanid(i), '"',trim(self%hdfname(i)), &
-                     & '"', real(self%scans(i)%proctime/self%scans(i)%n_proctime,sp),real(self%spinaxis(i,:),sp)
-             end if
-          end if
-          !call update_status(status, "tod_loop2")
-
+       ! Compute chisquare
+       do j = 1, sd%ndet
+          if (.not. self%scans(i)%d(j)%accept) cycle
+          call self%compute_chisq(i, j, sd%mask(:,j), sd%s_sky(:,j), sd%s_sl(:,j) + sd%s_orb(:,j), sd%n_corr(:,j))
        end do
 
-       call mpi_allreduce(mpi_in_place, dipole_mod, size(dipole_mod), MPI_DOUBLE_PRECISION, MPI_SUM, self%info%comm, ierr)
+       ! Select data
+       if (select_data) call remove_bad_data(self, i, sd%flag)
 
-!       if (self%myid == 0) then
-!          write(*, *) "CHECKPOINT"
-!          write(*, *) dipole_mod
-!       end if
+       ! Compute chisquare for bandpass fit
+       if (sample_abs_bandpass) call compute_chisq_abs_bp(self, i, sd, chisq_S)
 
-       if (do_oper(samp_acal)) then
-          call wall_time(t1)
-          call sample_abscal_from_orbital(self, handle, A_abscal, b_abscal)
-          call wall_time(t2); t_tot(16) = t_tot(16) + t2-t1
+       ! Compute binned map
+       allocate(d_calib(self%output_n_maps,sd%ntod, sd%ndet))
+       call compute_calibrated_data(self, i, sd, d_calib)
+       
+       ! Output 4D map; note that psi is zero-base in 4D maps, and one-base in Commander
+       if (self%output_4D_map > 0) then
+          if (mod(iter-1,self%output_4D_map) == 0) then
+             call output_4D_maps_hdf(trim(chaindir) // '/tod_4D_chain'//ctext//'_proc' // myid_text // '.h5', &
+                  & samptext, self%scanid(i), self%nside, self%npsi, &
+                  & self%label, self%horn_id, real(self%polang*180/pi,sp), &
+                  & real(self%scans(i)%d%sigma0/self%scans(i)%d%gain,sp), &
+                  & sd%pix(:,:,1), sd%psi(:,:,1)-1, d_calib(1,:,:), iand(sd%flag,self%flag0), &
+                  & self%scans(i)%d(:)%accept)
+          end if
        end if
 
-       if (do_oper(samp_rcal)) then
-          call wall_time(t1)
-          call sample_relcal(self, handle, A_abscal, b_abscal)
-          call wall_time(t2); t_tot(16) = t_tot(16) + t2-t1
+       ! Bin TOD
+       call bin_TOD(self, i, sd%pix(:,:,1), sd%psi(:,:,1), sd%flag, d_calib, binmap)
+
+       ! Update scan list
+       call wall_time(t1)
+       self%scans(i)%proctime   = self%scans(i)%proctime   + t2-t1
+       self%scans(i)%n_proctime = self%scans(i)%n_proctime + 1
+       if (output_scanlist) then
+          write(slist(i),*) self%scanid(i), '"',trim(self%hdfname(i)), &
+               & '"', real(self%scans(i)%proctime/self%scans(i)%n_proctime,sp),&
+               & real(self%spinaxis(i,:),sp)
        end if
 
-       if (do_oper(samp_G)) then
-          call wall_time(t1)
-          call sample_smooth_gain(self, handle, dipole_mod)
-          call wall_time(t2); t_tot(4) = t_tot(4) + t2-t1
-       end if
-
-       call wall_time(t7)
+       ! Clean up
+       call sd%dealloc
+       deallocate(s_buf, d_calib)
 
     end do
-    call wall_time(t4)
 
     ! Output latest scan list with new timing information
-    if (do_oper(output_slist)) then
-       call update_status(status, "scanlist1")
-       call wall_time(t1)
-       call self%output_scan_list(slist)
-       call wall_time(t2); t_tot(20) = t_tot(20) + t2-t1
-       call update_status(status, "scanlist2")
+    if (output_scanlist) call self%output_scan_list(slist)
+
+    ! Solve for maps
+    call syncronize_binmap(binmap, self)
+    if (sample_rel_bandpass) then
+       call finalize_binned_map(self, binmap, handle, rms_out, 1.d6, chisq_S=chisq_S, mask=procmask2)
+    else
+       call finalize_binned_map(self, binmap, handle, rms_out, 1.d6)
     end if
+    map_out%map = binmap%outmaps(1)%p%map
 
-    ! Solve combined map, summed over all pixels
-    call wall_time(t1)
-    call update_status(status, "shared1")
-    if (sA_map%init) then
-       do i = 0, self%numprocs_shared-1
-          !call update_status(status, "tod_share_loop")
-          start_chunk = mod(self%myid_shared+i,self%numprocs_shared)*chunk_size
-          end_chunk   = min(start_chunk+chunk_size-1,npix-1)
-          do while (start_chunk < npix)
-             if (self%pix2ind(start_chunk) /= -1) exit
-             start_chunk = start_chunk+1
-          end do
-          do while (end_chunk >= start_chunk)
-             if (self%pix2ind(end_chunk) /= -1) exit
-             end_chunk = end_chunk-1
-          end do
-          if (start_chunk < npix)       start_chunk = self%pix2ind(start_chunk)
-          if (end_chunk >= start_chunk) end_chunk   = self%pix2ind(end_chunk)
-
-          call mpi_win_fence(0, sA_map%win, ierr)
-          call mpi_win_fence(0, sb_map%win, ierr)
-          do j = start_chunk, end_chunk
-             sA_map%a(:,self%ind2pix(j)+1) = sA_map%a(:,self%ind2pix(j)+1) + &
-                  & A_map(:,j)
-             sb_map%a(:,:,self%ind2pix(j)+1) = sb_map%a(:,:,self%ind2pix(j)+1) + &
-                  & b_map(:,:,j)
-          end do
-          if (do_oper(samp_mono)) then
-             call mpi_win_fence(0, sb_mono%win, ierr)
-             do j = start_chunk, end_chunk
-                sb_mono%a(:,self%ind2pix(j)+1,:) = sb_mono%a(:,self%ind2pix(j)+1,:) + &
-                     & b_mono(:,j,:)
-             end do
-          end if
-       end do
-       call mpi_win_fence(0, sA_map%win, ierr)
-       call mpi_win_fence(0, sb_map%win, ierr)
-       if (do_oper(samp_mono)) call mpi_win_fence(0, sb_mono%win, ierr)
-
-       call update_status(status, "shared2")
-
-       call update_status(status, "finalize1")
-       Sfilename = trim(prefix) // 'Smap'// trim(postfix)
-       if (do_oper(samp_mono)) then
-          if (do_oper(prep_relbp)) then
-             call finalize_binned_map(self, handle, sA_map, sb_map, rms_out, outmaps=outmaps, sb_mono=sb_mono, sys_mono=sys_mono, chisq_S=chisq_S, Sfile=Sfilename, mask=sprocmask2%a)
-          else
-             call finalize_binned_map(self, handle, sA_map, sb_map, rms_out, outmaps=outmaps, sb_mono=sb_mono, sys_mono=sys_mono)
-          end if
-!!$          condmap => comm_map(self%info)
-!!$          call self%finalize_binned_map(handle, sA_map, sb_map, outmaps, rms_out, sb_mono=sb_mono, sys_mono=sys_mono, condmap=condmap)
-!!$          call condmap%writeFITS("cond.fits")
-!!$          call condmap%dealloc()
-       else
-          !condmap => comm_map(self%info)
-          if (do_oper(prep_relbp)) then
-             call finalize_binned_map(self, handle, sA_map, sb_map, rms_out, outmaps=outmaps, chisq_S=chisq_S, Sfile=Sfilename, mask=sprocmask2%a)
-          else
-             call finalize_binned_map(self, handle, sA_map, sb_map, rms_out, outmaps=outmaps)
-          end if
-          !call condmap%writeFITS("cond.fits")
-          !call condmap%dealloc()
-       end if
-
-       if (do_oper(samp_bp)) then
-          call wall_time(t1)
-          call sample_bp(self, iter, delta, map_sky, handle, chisq_S)
-          call wall_time(t2); t_tot(17) = t_tot(17) + t2-t1
-       end if
-
-       call update_status(status, "finalize2")
-       map_out%map = outmaps(1)%p%map
-
-       ! Sample monopole coefficients
-       if (do_oper(samp_mono)) then
-          call sample_mono(self, handle, sys_mono, outmaps(2)%p, rms_out, &
-               & self%procmask)
-       end if
-
-       ! Update bandpass parameters
+    ! Sample bandpass parameters
+    if (sample_rel_bandpass .or. sample_abs_bandpass) then
+       call sample_bp(self, iter, delta, map_sky, handle, chisq_S)
        self%bp_delta = delta(:,:,1)
-
-       ! Output maps to disk
-       if (.false. .and. trim(self%freq) == '030') then
-          if (self%myid == 0) write(*,*) 'Boosting rms 5x'
-          rms_out%map = 5*rms_out%map 
-       end if
-       call map_out%writeFITS(trim(prefix)//'map'//trim(postfix))
-       call rms_out%writeFITS(trim(prefix)//'rms'//trim(postfix))
-
-       if (self%output_n_maps > 1) call outmaps(2)%p%writeFITS(trim(prefix)//'res'//trim(postfix))
-       if (self%output_n_maps > 2) call outmaps(3)%p%writeFITS(trim(prefix)//'ncorr'//trim(postfix))
-       if (self%output_n_maps > 3) call outmaps(4)%p%writeFITS(trim(prefix)//'bpcorr'//trim(postfix))
-       if (self%output_n_maps > 4) call outmaps(5)%p%writeFITS(trim(prefix)//'mono'//trim(postfix))
-       if (self%output_n_maps > 5) call outmaps(6)%p%writeFITS(trim(prefix)//'orb'//trim(postfix))
-       if (self%output_n_maps > 6) call outmaps(7)%p%writeFITS(trim(prefix)//'sl'//trim(postfix))
-       if (self%output_n_maps > 7) call outmaps(8)%p%writeFITS(trim(prefix)//'zodi'//trim(postfix))
-
-       call update_status(status, "finalize3")
-
     end if
+   
+    ! Output maps to disk
+    call map_out%writeFITS(trim(prefix)//'map'//trim(postfix))
+    call rms_out%writeFITS(trim(prefix)//'rms'//trim(postfix))
+    if (self%output_n_maps > 1) call binmap%outmaps(2)%p%writeFITS(trim(prefix)//'res'//trim(postfix))
+    if (self%output_n_maps > 2) call binmap%outmaps(3)%p%writeFITS(trim(prefix)//'ncorr'//trim(postfix))
+    if (self%output_n_maps > 3) call binmap%outmaps(4)%p%writeFITS(trim(prefix)//'bpcorr'//trim(postfix))
+    if (self%output_n_maps > 5) call binmap%outmaps(5)%p%writeFITS(trim(prefix)//'orb'//trim(postfix))
+    if (self%output_n_maps > 6) call binmap%outmaps(6)%p%writeFITS(trim(prefix)//'sl'//trim(postfix))
+    if (self%output_n_maps > 7) call binmap%outmaps(7)%p%writeFITS(trim(prefix)//'zodi'//trim(postfix))
 
-    if (self%first_call) then
-       call mpi_reduce(ntot,    i, 1, MPI_INTEGER, MPI_SUM, &
-            & self%numprocs/2, self%info%comm, ierr)
-       ntot = i
-       call mpi_reduce(naccept, i, 1, MPI_INTEGER, MPI_SUM, &
-            & self%numprocs/2, self%info%comm, ierr)
-       naccept = i
-    end if
-    call wall_time(t2); t_tot(10) = t_tot(10) + t2-t1
-
-    call wall_time(t6)
-    if (self%myid == self%numprocs/2) then
-       write(*,*) '  Time dist sky   = ', t_tot(9)
-       write(*,*) '  Time sl precomp = ', t_tot(13)
-       write(*,*) '  Time decompress = ', t_tot(11)
-       write(*,*) '  Time alloc      = ', t_tot(18)
-       write(*,*) '  Time project    = ', t_tot(1)
-       write(*,*) '  Time orbital    = ', t_tot(2)
-       write(*,*) '  Time sl interp  = ', t_tot(12)
-       write(*,*) '  Time ncorr      = ', t_tot(3)
-       write(*,*) '  Time gain       = ', t_tot(4)
-       write(*,*) '  Time absgain    = ', t_tot(14)
-       write(*,*) '  Time sel data   = ', t_tot(15)
-       write(*,*) '  Time clean      = ', t_tot(5)
-       write(*,*) '  Time noise      = ', t_tot(6)
-       write(*,*) '  Time samp abs   = ', t_tot(16)
-       write(*,*) '  Time samp bp    = ', t_tot(17)
-       write(*,*) '  Time chisq      = ', t_tot(7)
-       write(*,*) '  Time bin        = ', t_tot(8)
-       if (self%enable_tod_simulations) write(*,*) '  Time tod sims   = ', t_tot(23)
-       write(*,*) '  Time scanlist   = ', t_tot(20)
-       write(*,*) '  Time final      = ', t_tot(10)
-       if (self%first_call) then
-!!$          write(*,*) '  Time total      = ', t6-t5, &
-!!$               & ', accept rate = ', real(naccept,sp) / ntot
-       else
-          write(*,*) '  Time total      = ', t6-t5, sum(t_tot(1:18))
-       end if
-    end if
-
-
-    ! Clean up temporary arrays
-    deallocate(A_abscal, b_abscal, chisq_S)
-    if (allocated(A_map)) deallocate(A_map, b_map)
-    if (sA_map%init)  call dealloc_shared_2d_dp(sA_map)
-    if (sb_map%init)  call dealloc_shared_3d_dp(sb_map)
-    if (sb_mono%init) call dealloc_shared_3d_dp(sb_mono)
-    if (allocated(b_mono)) deallocate(b_mono)
-    if (allocated(sys_mono)) deallocate(sys_mono)
+    ! Clean up
+    call binmap%dealloc()
     if (allocated(slist)) deallocate(slist)
-    if (allocated(dipole_mod)) deallocate(dipole_mod)
-
-    if (allocated(outmaps)) then
-       do i = 1, nout
-          call outmaps(i)%p%dealloc
-       end do
-       deallocate(outmaps)
-    end if
-
-    if (sprocmask%init)  call dealloc_shared_1d_int(sprocmask)
-    if (sprocmask2%init) call dealloc_shared_1d_int(sprocmask2)
-    deallocate(map_sky)
-
-    if (correct_sl) then
+    deallocate(map_sky, procmask, procmask2)
+    if (self%correct_sl) then
        do i = 1, self%ndet
           call self%slconv(i)%p%dealloc(); deallocate(self%slconv(i)%p)
        end do
     end if
 
-    call int2string(iter, ctext)
-    call update_status(status, "tod_end"//ctext)
-
     ! Parameter to check if this is first time routine has been
     self%first_call = .false.
+
+    call update_status(status, "tod_end"//ctext)
 
   end subroutine process_LFI_tod
 

--- a/commander3/src/comm_tod_LFI_mod.f90
+++ b/commander3/src/comm_tod_LFI_mod.f90
@@ -67,7 +67,7 @@ module comm_tod_LFI_mod
 
 
   type, extends(comm_tod) :: comm_LFI_tod
-     class(orbdipole_pointer), allocatable :: orb_dp !orbital dipole calculator
+    class(orbdipole_pointer), allocatable :: orb_dp !orbital dipole calculator
    contains
      procedure     :: process_tod        => process_LFI_tod
      procedure     :: simulate_LFI_tod
@@ -609,20 +609,20 @@ contains
           ! Construct sky signal template
           call wall_time(t1)
           if (do_oper(bin_map) .or. do_oper(prep_relbp)) then
-             call project_sky(self, map_sky(:,:,:,1), pix, psi, flag, &
+             call project_sky(self, map_sky(:,:,:,1), pix(:,:,1), psi(:,:,1), flag, &
                   & sprocmask%a, i, s_sky, mask, s_bp=s_bp)
           else
-             call project_sky(self, map_sky(:,:,:,1), pix, psi, flag, &
+             call project_sky(self, map_sky(:,:,:,1), pix(:,:,1), psi(:,:,1), flag, &
                   & sprocmask%a, i, s_sky, mask)
           end if
           if (do_oper(prep_relbp)) then
              do j = 2, ndelta
-                call project_sky(self, map_sky(:,:,:,j), pix, psi, flag, &
+                call project_sky(self, map_sky(:,:,:,j), pix(:,:,1), psi(:,:,1), flag, &
                      & sprocmask2%a, i, s_sky_prop(:,:,j), mask2, s_bp=s_bp_prop(:,:,j))
              end do
           else if (do_oper(prep_absbp)) then
              do j = 2, ndelta
-                call project_sky(self, map_sky(:,:,:,j), pix, psi, flag, &
+                call project_sky(self, map_sky(:,:,:,j), pix(:,:,1), psi(:,:,1), flag, &
                      & sprocmask2%a, i, s_sky_prop(:,:,j), mask2)
              end do
           end if

--- a/commander3/src/comm_tod_SPIDER_mod.f90
+++ b/commander3/src/comm_tod_SPIDER_mod.f90
@@ -47,7 +47,7 @@ module comm_tod_SPIDER_mod
 
 
   type, extends(comm_tod) :: comm_SPIDER_tod
-  class(orbdipole_pointer), allocatable :: orb_dp !orbital dipole calculator
+     !class(orbdipole_pointer), allocatable :: orb_dp !orbital dipole calculator
    contains
      procedure     :: process_tod        => process_SPIDER_tod
   end type comm_SPIDER_tod
@@ -591,24 +591,25 @@ contains
           !call update_status(status, "tod_decomp")
           ! Construct sky signal template
           call wall_time(t1)
-          if (do_oper(bin_map) .or. do_oper(prep_relbp)) then 
-             call project_sky(self, map_sky(:,:,:,1), pix(:,:,1), psi(:,:,1), flag, &
-                  & sprocmask%a, i, s_sky, mask, s_bp=s_bp)  
-          else 
-             call project_sky(self, map_sky(:,:,:,1), pix(:,:,1), psi(:,:,1), flag, &
-                  & sprocmask%a, i, s_sky, mask)
-          end if
-          if (do_oper(prep_relbp)) then
-             do j = 2, ndelta
-                call project_sky(self, map_sky(:,:,:,j), pix(:,:,1), psi(:,:,1), flag, &
-                     & sprocmask2%a, i, s_sky_prop(:,:,j), mask2, s_bp=s_bp_prop(:,:,j))  
-             end do
-          else if (do_oper(prep_absbp)) then
-             do j = 2, ndelta
-                call project_sky(self, map_sky(:,:,:,j), pix(:,:,1), psi(:,:,1), flag, &
-                     & sprocmask2%a, i, s_sky_prop(:,:,j), mask2)  
-             end do
-          end if
+!!$ HKE: commented out this
+!!$          if (do_oper(bin_map) .or. do_oper(prep_relbp)) then 
+!!$             call project_sky(self, map_sky(:,:,:,1), pix(:,:,1), psi(:,:,1), flag, &
+!!$                  & sprocmask%a, i, s_sky, mask, s_bp=s_bp)  
+!!$          else 
+!!$             call project_sky(self, map_sky(:,:,:,1), pix(:,:,1), psi(:,:,1), flag, &
+!!$                  & sprocmask%a, i, s_sky, mask)
+!!$          end if
+!!$          if (do_oper(prep_relbp)) then
+!!$             do j = 2, ndelta
+!!$                call project_sky(self, map_sky(:,:,:,j), pix(:,:,1), psi(:,:,1), flag, &
+!!$                     & sprocmask2%a, i, s_sky_prop(:,:,j), mask2, s_bp=s_bp_prop(:,:,j))  
+!!$             end do
+!!$          else if (do_oper(prep_absbp)) then
+!!$             do j = 2, ndelta
+!!$                call project_sky(self, map_sky(:,:,:,j), pix(:,:,1), psi(:,:,1), flag, &
+!!$                     & sprocmask2%a, i, s_sky_prop(:,:,j), mask2)  
+!!$             end do
+!!$          end if
           if (main_iter == 1 .and. self%first_call) then
              do j = 1, ndet
                 if (all(mask(:,j) == 0)) self%scans(i)%d(j)%accept = .false.
@@ -1151,13 +1152,14 @@ contains
 
              call wall_time(t1)
 
-             if (do_oper(samp_mono)) then
-                call bin_TOD(self, d_calib, pix(:,:,1), &
-                     & psi(:,:,1), flag, A_map, b_map, i, do_oper(prep_relbp), b_mono=b_mono)
-             else
-                call bin_TOD(self, d_calib, pix(:,:,1), &
-                     & psi(:,:,1), flag, A_map, b_map, i, do_oper(prep_relbp))
-             end if
+!!$ HKE: commented out this
+!!$             if (do_oper(samp_mono)) then
+!!$                call bin_TOD(self, d_calib, pix(:,:,1), &
+!!$                     & psi(:,:,1), flag, A_map, b_map, i, do_oper(prep_relbp), b_mono=b_mono)
+!!$             else
+!!$                call bin_TOD(self, d_calib, pix(:,:,1), &
+!!$                     & psi(:,:,1), flag, A_map, b_map, i, do_oper(prep_relbp))
+!!$             end if
              deallocate(d_calib)
              call wall_time(t2); t_tot(8) = t_tot(8) + t2-t1
           end if
@@ -1276,26 +1278,23 @@ contains
 
        call update_status(status, "finalize1")
        Sfilename = trim(prefix) // 'Smap'// trim(postfix)
-       if (do_oper(samp_mono)) then
-          if (do_oper(prep_relbp)) then
-             call finalize_binned_map(self, handle, sA_map, sb_map, rms_out, outmaps=outmaps, sb_mono=sb_mono, sys_mono=sys_mono, chisq_S=chisq_S, Sfile=Sfilename, mask=sprocmask2%a)
-          else
-             call finalize_binned_map(self, handle, sA_map, sb_map, rms_out, outmaps=outmaps, sb_mono=sb_mono, sys_mono=sys_mono)
-          end if
-!!$          condmap => comm_map(self%info)
-!!$          call self%finalize_binned_map(handle, sA_map, sb_map, outmaps, rms_out, sb_mono=sb_mono, sys_mono=sys_mono, condmap=condmap)
-!!$          call condmap%writeFITS("cond.fits")
-!!$          call condmap%dealloc()
-       else
-          !condmap => comm_map(self%info)
-          if (do_oper(prep_relbp)) then
-             call finalize_binned_map(self, handle, sA_map, sb_map, rms_out, outmaps=outmaps, chisq_S=chisq_S, Sfile=Sfilename, mask=sprocmask2%a)
-          else
-             call finalize_binned_map(self, handle, sA_map, sb_map, rms_out, outmaps=outmaps)
-          end if
-          !call condmap%writeFITS("cond.fits")
-          !call condmap%dealloc()
-       end if
+!!$ HKE: commented out this
+!!$       if (do_oper(samp_mono)) then
+!!$          if (do_oper(prep_relbp)) then
+!!$             call finalize_binned_map(self, handle, sA_map, sb_map, rms_out, outmaps=outmaps, sb_mono=sb_mono, sys_mono=sys_mono, chisq_S=chisq_S, Sfile=Sfilename, mask=sprocmask2%a)
+!!$          else
+!!$             call finalize_binned_map(self, handle, sA_map, sb_map, rms_out, outmaps=outmaps, sb_mono=sb_mono, sys_mono=sys_mono)
+!!$          end if
+!!$       else
+!!$          !condmap => comm_map(self%info)
+!!$          if (do_oper(prep_relbp)) then
+!!$             call finalize_binned_map(self, handle, sA_map, sb_map, rms_out, outmaps=outmaps, chisq_S=chisq_S, Sfile=Sfilename, mask=sprocmask2%a)
+!!$          else
+!!$             call finalize_binned_map(self, handle, sA_map, sb_map, rms_out, outmaps=outmaps)
+!!$          end if
+!!$          !call condmap%writeFITS("cond.fits")
+!!$          !call condmap%dealloc()
+!!$       end if
 
        if (do_oper(samp_bp)) then
           call wall_time(t1)
@@ -1307,10 +1306,11 @@ contains
        map_out%map = outmaps(1)%p%map
        
        ! Sample monopole coefficients
-       if (do_oper(samp_mono)) then
-          call sample_mono(self, handle, sys_mono, outmaps(2)%p, rms_out, &
-               & self%procmask)
-       end if
+!!$ HKE: Commented out this; no support for monopole sampling anymore
+!!$       if (do_oper(samp_mono)) then
+!!$          call sample_mono(self, handle, sys_mono, outmaps(2)%p, rms_out, &
+!!$               & self%procmask)
+!!$       end if
 
        ! Update bandpass parameters
        self%bp_delta = delta(:,:,1)

--- a/commander3/src/comm_tod_SPIDER_mod.f90
+++ b/commander3/src/comm_tod_SPIDER_mod.f90
@@ -592,20 +592,20 @@ contains
           ! Construct sky signal template
           call wall_time(t1)
           if (do_oper(bin_map) .or. do_oper(prep_relbp)) then 
-             call project_sky(self, map_sky(:,:,:,1), pix, psi, flag, &
+             call project_sky(self, map_sky(:,:,:,1), pix(:,:,1), psi(:,:,1), flag, &
                   & sprocmask%a, i, s_sky, mask, s_bp=s_bp)  
           else 
-             call project_sky(self, map_sky(:,:,:,1), pix, psi, flag, &
+             call project_sky(self, map_sky(:,:,:,1), pix(:,:,1), psi(:,:,1), flag, &
                   & sprocmask%a, i, s_sky, mask)
           end if
           if (do_oper(prep_relbp)) then
              do j = 2, ndelta
-                call project_sky(self, map_sky(:,:,:,j), pix, psi, flag, &
+                call project_sky(self, map_sky(:,:,:,j), pix(:,:,1), psi(:,:,1), flag, &
                      & sprocmask2%a, i, s_sky_prop(:,:,j), mask2, s_bp=s_bp_prop(:,:,j))  
              end do
           else if (do_oper(prep_absbp)) then
              do j = 2, ndelta
-                call project_sky(self, map_sky(:,:,:,j), pix, psi, flag, &
+                call project_sky(self, map_sky(:,:,:,j), pix(:,:,1), psi(:,:,1), flag, &
                      & sprocmask2%a, i, s_sky_prop(:,:,j), mask2)  
              end do
           end if

--- a/commander3/src/comm_tod_WMAP_mod.f90
+++ b/commander3/src/comm_tod_WMAP_mod.f90
@@ -68,7 +68,7 @@ module comm_tod_WMAP_mod
    logical(lgt), dimension(N_test) :: do_oper
 
    type, extends(comm_tod) :: comm_WMAP_tod
-      class(orbdipole_pointer), allocatable :: orb_dp ! orbital dipole calculator
+      !class(orbdipole_pointer), allocatable :: orb_dp ! orbital dipole calculator
       character(len=20), allocatable, dimension(:) :: labels ! names of fields
    contains
       procedure     :: process_tod => process_WMAP_tod
@@ -149,8 +149,8 @@ contains
       call constructor%load_instrument_file(nside_beam, nmaps_beam, pol_beam, cpar%comm_chain)
 
       allocate(constructor%slconv(constructor%ndet))
-      allocate (constructor%orb_dp)
-      constructor%orb_dp%p => comm_orbdipole(constructor, constructor%mbeam)
+      !allocate (constructor%orb_dp)
+      !constructor%orb_dp%p => comm_orbdipole(constructor, constructor%mbeam)
    end function constructor
 
    !**************************************************
@@ -427,16 +427,17 @@ contains
 
             ! Construct sky signal template
             call wall_time(t1)
-            if (do_oper(bin_map) .or. do_oper(prep_relbp)) then
-               call project_sky_differential(self, map_sky(:,:,:,1), pix, psi, flag, &
-                 & procmask, i, s_skyA, s_skyB, mask, s_bpA=s_bpA, s_bpB=s_bpB)
-            else
-               call project_sky_differential(self, map_sky(:,:,:,1), pix, psi, flag, &
-                    & procmask, i, s_skyA, s_skyB, mask)
-               s_bpA = 0.
-               s_bpB = 0.
-               s_bp  = 0.
-            end if
+!!$ HKE: commented out this
+!!$            if (do_oper(bin_map) .or. do_oper(prep_relbp)) then
+!!$               call project_sky_differential(self, map_sky(:,:,:,1), pix, psi, flag, &
+!!$                 & procmask, i, s_skyA, s_skyB, mask, s_bpA=s_bpA, s_bpB=s_bpB)
+!!$            else
+!!$               call project_sky_differential(self, map_sky(:,:,:,1), pix, psi, flag, &
+!!$                    & procmask, i, s_skyA, s_skyB, mask)
+!!$               s_bpA = 0.
+!!$               s_bpB = 0.
+!!$               s_bp  = 0.
+!!$            end if
             do j = 1, ndet
                if (.not. self%scans(i)%d(j)%accept) cycle
                s_sky(:, j) = (1d0+x_im(j))*s_skyA(:,j) - &
@@ -458,8 +459,8 @@ contains
             ! Construct orbital dipole template
             call wall_time(t1)
             if (.true.) then
-               call self%orb_dp%p%compute_orbital_dipole_pencil(i, pix(:,1), psi(:,1), s_orbA, 1d3)
-               call self%orb_dp%p%compute_orbital_dipole_pencil(i, pix(:,2), psi(:,2), s_orbB, 1d3)
+               !call self%orb_dp%p%compute_orbital_dipole_pencil(i, pix(:,1), psi(:,1), s_orbA, 1d3)
+               !call self%orb_dp%p%compute_orbital_dipole_pencil(i, pix(:,2), psi(:,2), s_orbB, 1d3)
                do j = 1, ndet
                   if (.not. self%scans(i)%d(j)%accept) cycle
                   s_orb_tot(:, j) = (1d0+x_im(j))*s_orbA(:,j) - &

--- a/commander3/src/comm_tod_driver_mod.f90
+++ b/commander3/src/comm_tod_driver_mod.f90
@@ -9,6 +9,7 @@ module comm_tod_driver_mod
   use comm_tod_mapmaking_mod
   use comm_zodi_mod
   use comm_shared_arr_mod
+  use omp_lib
   implicit none
 
 
@@ -639,5 +640,192 @@ contains
     deallocate(m_buf)
 
   end subroutine distribute_sky_maps
+
+  ! ************************************************
+  !
+  !> @brief Commander3 native simulation module. It
+  !! simulates correlated noise and then rewrites
+  !! the original timestreams inside the files.
+  !
+  !> @author Maksym Brilenkov
+  !
+  !> @param[in]
+  !> @param[out]
+  !
+  ! ************************************************
+  subroutine simulate_tod(self, scan_id, s_tot, handle)
+    implicit none
+    class(comm_tod), intent(inout) :: self
+    ! Parameter file variables
+    !type(comm_params),                     intent(in)    :: cpar
+    ! Other input/output variables
+    real(sp), allocatable, dimension(:,:), intent(in)    :: s_tot   !< total sky signal
+    integer(i4b),                          intent(in)    :: scan_id !< current PID
+    type(planck_rng),                      intent(inout) :: handle
+    ! Simulation variables
+    real(sp), allocatable, dimension(:,:) :: tod_per_detector !< simulated tods per detector
+    real(sp)                              :: gain   !< detector's gain value
+    real(sp)                              :: sigma0
+    real(sp) :: nu_knee
+    real(sp) :: alpha
+    real(sp) :: samprate
+    real(sp) :: fft_norm
+    integer(i4b)                          :: ntod !< total amount of ODs
+    integer(i4b)                          :: ndet !< total amount of detectors
+    ! HDF5 variables
+    character(len=512) :: mystring, mysubstring !< dummy values for string manipulation
+    integer(i4b)       :: myindex     !< dummy value for string manipulation
+    character(len=512) :: currentHDFFile !< hdf5 file which stores simulation output
+    character(len=6)   :: pidLabel
+    character(len=3)   :: detectorLabel
+    type(hdf_file)     :: hdf5_file   !< hdf5 file to work with
+    integer(i4b)       :: hdf5_error  !< hdf5 error status
+    integer(HID_T)     :: hdf5_file_id !< File identifier
+    integer(HID_T)     :: dset_id     !< Dataset identifier
+    integer(HSIZE_T), dimension(1) :: dims
+    ! Other variables
+    integer(i4b)                          :: i, j, k !< loop variables
+    integer(i4b)       :: mpi_err !< MPI error status
+    integer(i4b)       :: nomp !< Number of threads available
+    integer(i4b)       :: omp_err !< OpenMP error status
+    integer(i4b) :: omp_get_max_threads
+    integer(i4b) :: n, nfft
+    integer*8    :: plan_back
+    real(sp) :: nu
+    real(sp), allocatable, dimension(:,:) :: n_corr
+    real(sp),     allocatable, dimension(:) :: dt
+    complex(spc), allocatable, dimension(:) :: dv
+    character(len=10) :: processor_label   !< to have a nice output to screen
+
+    ! shortcuts
+    ntod = self%scans(scan_id)%ntod
+    ndet = self%ndet
+
+    ! Simulating 1/f noise
+    !write(*,*) "Simulating correlated noise"
+    nfft = 2 * ntod
+    n = nfft / 2 + 1
+    nomp = omp_get_max_threads()
+    call sfftw_init_threads(omp_err)
+    call sfftw_plan_with_nthreads(nomp)
+    ! planning FFTW - in principle we should do both forward and backward FFTW,
+    ! but in this case we can omit forward one and go directly with backward to
+    ! save some time on a whole operation.
+    allocate(dt(nfft), dv(0:n-1))
+    call sfftw_plan_dft_c2r_1d(plan_back, nfft, dv, dt, fftw_estimate + fftw_unaligned)
+    deallocate(dt, dv)
+
+    !$OMP PARALLEL PRIVATE(i, j, k, dt, dv, sigma0, nu, nu_knee, alpha)
+    allocate(dt(nfft), dv(0:n-1), n_corr(ntod, ndet))
+    !$OMP DO SCHEDULE(guided)
+    do j = 1, ndet
+      ! skipping iteration if scan was not accepted
+      if (.not. self%scans(scan_id)%d(j)%accept) cycle
+      ! getting gain for each detector (units, V / K)
+      ! (gain is assumed to be CONSTANT for EACH SCAN)
+      gain   = self%scans(scan_id)%d(j)%gain
+      sigma0 = self%scans(scan_id)%d(j)%sigma0
+      samprate = self%samprate
+      alpha    = self%scans(scan_id)%d(j)%alpha
+      ! knee frequency
+      nu_knee  = self%scans(scan_id)%d(j)%fknee
+      ! used when adding fluctuation terms to Fourier coeffs (depends on Fourier convention)
+      fft_norm = sqrt(1.d0 * nfft)
+      !
+      !dv(0) = dv(0) + fft_norm * sigma0 * cmplx(rand_gauss(handle),rand_gauss(handle)) / sqrt(2.0)
+      dv(0) = fft_norm * sigma0 * cmplx(rand_gauss(handle),rand_gauss(handle)) / sqrt(2.0)
+      do k = 1, (n - 1)
+        nu = k * (samprate / 2) / (n - 1)
+        !dv(k) = sigma0 * cmplx(rand_gauss(handle), rand_gauss(handle)) * sqrt(1 + (nu / nu_knee)**alpha) /sqrt(2          .0)
+        dv(k) = sigma0 * cmplx(rand_gauss(handle), rand_gauss(handle)) * sqrt((nu / nu_knee)**alpha) /sqrt(2.0)
+      end do
+      ! Executing Backward FFT
+      call sfftw_execute_dft_c2r(plan_back, dv, dt)
+      dt = dt / nfft
+      n_corr(:, j) = dt(1:ntod)
+      !write(*,*) "n_corr ", n_corr(:, j)
+    end do
+    !$OMP END DO
+    deallocate(dt, dv)
+    !$OMP END PARALLEL
+
+    call sfftw_destroy_plan(plan_back)
+
+    ! Allocating main simulations' array
+    allocate(tod_per_detector(ntod, ndet))       ! Simulated tod
+
+    ! Main simulation loop
+    do i = 1, ntod
+      do j = 1, ndet
+        ! skipping iteration if scan was not accepted
+        if (.not. self%scans(scan_id)%d(j)%accept) cycle
+        ! getting gain for each detector (units, V / K)
+        ! (gain is assumed to be CONSTANT for EACH SCAN)
+        gain   = self%scans(scan_id)%d(j)%gain
+        !write(*,*) "gain ", gain
+        sigma0 = self%scans(scan_id)%d(j)%sigma0
+        !write(*,*) "sigma0 ", sigma0
+        ! Simulating tods
+        tod_per_detector(i,j) = gain * s_tot(i,j) + n_corr(i, j) + sigma0 * rand_gauss(handle)
+        !tod_per_detector(i,j) = 0
+      end do
+    end do
+
+    !----------------------------------------------------------------------------------
+    ! Saving stuff to hdf file
+    ! Getting the full path and name of the current hdf file to overwrite
+    !----------------------------------------------------------------------------------
+    mystring = trim(self%hdfname(scan_id))
+    mysubstring = 'LFI_0'
+    myindex = index(trim(mystring), trim(mysubstring))
+    currentHDFFile = trim(self%sims_output_dir)//'/'//trim(mystring(myindex:))
+    !write(*,*) "hdf5name "//trim(self%hdfname(scan_id))
+    !write(*,*) "currentHDFFile "//trim(currentHDFFile)
+    ! Converting PID number into string value
+    call int2string(self%scanid(scan_id), pidLabel)
+    call int2string(self%myid, processor_label)
+    write(*,*) "Process: "//trim(processor_label)//" started writing PID: "//trim(pidLabel)//", into:"
+    write(*,*) trim(currentHDFFile)
+    ! For debugging
+    !call MPI_Finalize(mpi_err)
+    !stop
+
+    dims(1) = ntod
+    ! Initialize FORTRAN interface.
+    call h5open_f(hdf5_error)
+    ! Open an existing file - returns hdf5_file_id
+    call  h5fopen_f(currentHDFFile, H5F_ACC_RDWR_F, hdf5_file_id, hdf5_error)
+    do j = 1, ndet
+      detectorLabel = self%label(j)
+      ! Open an existing dataset.
+      call h5dopen_f(hdf5_file_id, trim(pidLabel)//'/'//trim(detectorLabel)//'/'//'tod', dset_id, hdf5_error)
+      ! Write tod data to a dataset
+      call h5dwrite_f(dset_id, H5T_IEEE_F32LE, tod_per_detector(:,j), dims, hdf5_error)
+      ! Close the dataset.
+      call h5dclose_f(dset_id, hdf5_error)
+    end do
+    ! Close the file.
+    call h5fclose_f(hdf5_file_id, hdf5_error)
+    ! Close FORTRAN interface.
+    call h5close_f(hdf5_error)
+
+    !write(*,*) "hdf5_error",  hdf5_error
+    ! freeing memory up
+    deallocate(n_corr, tod_per_detector)
+    write(*,*) "Process:", self%myid, "finished writing PID: "//trim(pidLabel)//"."
+
+    ! lastly, we need to copy an existing filelist.txt into simulation folder
+    ! and change the pointers to new files
+    !if (self%myid == 0) then
+    !  call system("cp "//trim(filelist)//" "//trim(simsdir))
+    !  !mystring = filelist
+    !  !mysubstring = ".txt"
+    !  !myindex = index(trim(mystring), trim(mysubstring))
+    !end if
+
+    ! For debugging
+    !call MPI_Finalize(mpi_err)
+    !stop
+  end subroutine simulate_tod
 
 end module comm_tod_driver_mod

--- a/commander3/src/comm_tod_driver_mod.f90
+++ b/commander3/src/comm_tod_driver_mod.f90
@@ -13,7 +13,7 @@ module comm_tod_driver_mod
 
 
   ! Class for uncompressed data for a given scan
-  type :: scan_data
+  type :: comm_scandata
      integer(i4b) :: ntod, ndet, nhorn, ndelta
      real(sp),     allocatable, dimension(:,:)     :: tod        ! Raw data
      real(sp),     allocatable, dimension(:,:)     :: n_corr     ! Correlated noise in V
@@ -31,7 +31,6 @@ module comm_tod_driver_mod
      integer(i4b), allocatable, dimension(:,:,:)   :: pix        ! Discretized pointing 
      integer(i4b), allocatable, dimension(:,:,:)   :: psi        ! Discretized polarization angle
      integer(i4b), allocatable, dimension(:,:)     :: flag       ! Quality flags
-     real(sp),     allocatable, dimension(:,:)     :: s_buf      ! Buffer
 
      real(sp),     allocatable, dimension(:,:)     :: s_totA     ! Total signal, horn A (differential only)
      real(sp),     allocatable, dimension(:,:)     :: s_totB     ! Total signal, horn B (differential only)
@@ -39,7 +38,7 @@ module comm_tod_driver_mod
      procedure  :: init_singlehorn   => init_scan_data_singlehorn
      procedure  :: init_differential => init_scan_data_differential
      procedure  :: dealloc           => dealloc_scan_data
-  end type scan_data
+  end type comm_scandata
 
 
 contains
@@ -48,22 +47,21 @@ contains
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   !  Scan data routines
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  subroutine init_scan_data_singlehorn(self, tod, scan, map_sky, sprocmask, sprocmask2, &
-       & init_s_bp, init_s_bp_prop, init_s_sky_prop, symmetrize_flags)
+  subroutine init_scan_data_singlehorn(self, tod, scan, map_sky, procmask, procmask2, &
+       & init_s_bp, init_s_bp_prop, init_s_sky_prop)
     implicit none
-    class(scan_data),                      intent(inout)          :: self    
-    class(comm_tod),                       intent(inout)          :: tod
-    integer(i4b),                          intent(in)             :: scan
-    real(sp),          dimension(:,:,:,:), intent(in)             :: map_sky
-    type(shared_1d_int),                   intent(in)             :: sprocmask
-    type(shared_1d_int),                   intent(in)             :: sprocmask2
-    logical(lgt),                          intent(in),   optional :: init_s_bp
-    logical(lgt),                          intent(in),   optional :: init_s_bp_prop
-    logical(lgt),                          intent(in),   optional :: init_s_sky_prop
-    logical(lgt),                          intent(in),   optional :: symmetrize_flags
+    class(comm_scandata),                      intent(inout)          :: self    
+    class(comm_tod),                           intent(inout)          :: tod
+    integer(i4b),                              intent(in)             :: scan
+    real(sp),          dimension(1:,1:,0:,1:), intent(in)             :: map_sky
+    real(sp),          dimension(0:),          intent(in)             :: procmask
+    real(sp),          dimension(0:),          intent(in)             :: procmask2
+    logical(lgt),                              intent(in),   optional :: init_s_bp
+    logical(lgt),                              intent(in),   optional :: init_s_bp_prop
+    logical(lgt),                              intent(in),   optional :: init_s_sky_prop
 
     integer(i4b) :: j, k, ndelta
-    logical(lgt) :: init_s_bp_, init_s_bp_prop_, init_s_sky_prop_, symmetrize_flags_
+    logical(lgt) :: init_s_bp_, init_s_bp_prop_, init_s_sky_prop_
 
     if (tod%nhorn /= 1) then
        write(*,*) 'Error: init_scan_data_singlehorn only applicable for 1-horn experiments'
@@ -77,7 +75,6 @@ contains
        init_s_bp_prop_ = init_s_bp_prop
        init_s_sky_prop_ = init_s_sky_prop
     end if
-    symmetrize_flags_ = .false.; if (present(symmetrize_flags)) symmetrize_flags_ = symmetrize_flags
 
     self%ntod   = tod%scans(scan)%ntod
     self%ndet   = tod%ndet
@@ -92,7 +89,6 @@ contains
     allocate(self%s_bp(self%ntod, self%ndet))
     allocate(self%s_orb(self%ntod, self%ndet))
     allocate(self%s_tot(self%ntod, self%ndet))
-    allocate(self%s_buf(self%ntod, self%ndet))
     allocate(self%mask(self%ntod, self%ndet))
     allocate(self%pix(self%ntod, self%ndet, self%nhorn))
     allocate(self%psi(self%ntod, self%ndet, self%nhorn))
@@ -109,7 +105,7 @@ contains
        call tod%decompress_pointing_and_flags(scan, j, self%pix(:,j,:), &
             & self%psi(:,j,:), self%flag(:,j))
     end do
-    if (symmetrize_flags_) call tod%symmetrize_flags(self%flag)
+    if (tod%symm_flags) call tod%symmetrize_flags(self%flag)
     
     ! Prepare TOD
     do j = 1, self%ndet
@@ -124,22 +120,22 @@ contains
     ! Construct sky signal template
     if (init_s_bp_) then
        call project_sky(tod, map_sky(:,:,:,1), self%pix(:,:,1), self%psi(:,:,1), self%flag, &
-            & sprocmask%a, scan, self%s_sky, self%mask, s_bp=self%s_bp)
+            & procmask, scan, self%s_sky, self%mask, s_bp=self%s_bp)
     else
        call project_sky(tod, map_sky(:,:,:,1), self%pix(:,:,1), self%psi(:,:,1), self%flag, &
-            & sprocmask%a, scan, self%s_sky, self%mask)
+            & procmask, scan, self%s_sky, self%mask)
     end if
 
     ! Set up (optional) bandpass sampling quantities (s_sky_prop, mask2 and bp_prop)
     if (init_s_bp_prop_) then
        do j = 2, size(map_sky,4)
           call project_sky(tod, map_sky(:,:,:,j), self%pix(:,:,1), self%psi(:,:,1), self%flag, &
-               & sprocmask2%a, scan, self%s_sky_prop(:,:,j), self%mask2, s_bp=self%s_bp_prop(:,:,j))
+               & procmask2, scan, self%s_sky_prop(:,:,j), self%mask2, s_bp=self%s_bp_prop(:,:,j))
        end do
     else if (init_s_sky_prop_) then
        do j = 2, size(map_sky,4)
           call project_sky(tod, map_sky(:,:,:,j), self%pix(:,:,1), self%psi(:,:,1), self%flag, &
-               & sprocmask2%a, scan, self%s_sky_prop(:,:,j), self%mask2)
+               & procmask2, scan, self%s_sky_prop(:,:,j), self%mask2)
        end do
     end if
 
@@ -151,11 +147,7 @@ contains
     end do
     
     ! Construct orbital dipole template
-    if (tod%orb_4pi_beam) then
-       !call tod%orb_dp%p%compute_orbital_dipole_4pi(scan, self%pix(:,:,1), self%psi(:,:,1), self%s_orb(:,:,1))
-    else
-       !call tod%orb_dp%p%compute_orbital_dipole_pencil(scan, self%pix(:,:,1), self%psi(:,:,1), self%s_orb(:,:,1))
-    end if
+    call tod%construct_dipole_template(scan, self%pix(:,:,1), self%psi(:,:,1), .true., self%s_orb)
 
     ! Construct zodical light template
     if (tod%subtract_zodi) then
@@ -197,30 +189,24 @@ contains
 
 
   subroutine init_scan_data_differential(self, tod, scan, map_sky, procmask, procmask2, &
-       & init_s_bp, init_s_bp_prop, init_s_sky_prop, symmetrize_flags)
+       & init_s_bp, init_s_bp_prop, init_s_sky_prop)
     implicit none
-    class(scan_data),                      intent(inout)          :: self    
-    class(comm_tod),                       intent(inout)          :: tod
-    integer(i4b),                          intent(in)             :: scan
-    real(sp),          dimension(:,:,:,:), intent(in)             :: map_sky
-    integer(i4b),      dimension(0:),      intent(in)             :: procmask
-    integer(i4b),      dimension(0:),      intent(in)             :: procmask2
-    logical(lgt),                          intent(in),   optional :: init_s_bp
-    logical(lgt),                          intent(in),   optional :: init_s_bp_prop
-    logical(lgt),                          intent(in),   optional :: init_s_sky_prop
-    logical(lgt),                          intent(in),   optional :: symmetrize_flags
+    class(comm_scandata),                      intent(inout)          :: self    
+    class(comm_tod),                           intent(inout)          :: tod
+    integer(i4b),                              intent(in)             :: scan
+    real(sp),          dimension(1:,1:,0:,1:), intent(in)             :: map_sky
+    real(sp),          dimension(0:),          intent(in)             :: procmask
+    real(sp),          dimension(0:),          intent(in)             :: procmask2
+    logical(lgt),                              intent(in),   optional :: init_s_bp
+    logical(lgt),                              intent(in),   optional :: init_s_bp_prop
+    logical(lgt),                              intent(in),   optional :: init_s_sky_prop
 
     integer(i4b) :: j, k, ndelta
-    logical(lgt) :: init_s_bp_, init_s_bp_prop_, init_s_sky_prop_, symmetrize_flags_
+    logical(lgt) :: init_s_bp_, init_s_bp_prop_, init_s_sky_prop_
     real(sp),     allocatable, dimension(:,:)     :: s_bufA, s_bufB, s_buf2A, s_buf2B      ! Buffer
 
     if (tod%nhorn /= 2) then
        write(*,*) 'Error: init_scan_data_differential only applicable for 2-horn experiments'
-       stop
-    end if
-
-    if (present(symmetrize_flags)) then
-       write(*,*) 'Error: init_scan_daa_differential does not support symmetrize_flags'
        stop
     end if
 
@@ -231,7 +217,6 @@ contains
        init_s_bp_prop_ = init_s_bp_prop
        init_s_sky_prop_ = init_s_sky_prop
     end if
-    symmetrize_flags_ = .false.; if (present(symmetrize_flags)) symmetrize_flags_ = symmetrize_flags
 
     self%ntod   = tod%scans(scan)%ntod
     self%ndet   = tod%ndet
@@ -248,7 +233,6 @@ contains
     allocate(self%s_tot(self%ntod, self%ndet))
     allocate(self%s_totA(self%ntod, self%ndet))
     allocate(self%s_totB(self%ntod, self%ndet))
-    allocate(self%s_buf(self%ntod, self%ndet))
     allocate(self%mask(self%ntod, self%ndet))
     allocate(self%pix(self%ntod, 1, self%nhorn))
     allocate(self%psi(self%ntod, 1, self%nhorn))
@@ -327,19 +311,16 @@ contains
     end do
     
     ! Construct orbital dipole template
-    if (tod%orb_4pi_beam) then
-       !call tod%orb_dp%p%compute_orbital_dipole_4pi(scan, self%pix(:,1,1), psi(:,1,1), s_bufA)
-       !call tod%orb_dp%p%compute_orbital_dipole_4pi(scan, self%pix(:,1,2), psi(:,1,2), s_bufB)
-    else
-       ! Duncan: Fix units on your side to get rid of the 1d3 scaling factor
-       !call tod%orb_dp%p%compute_orbital_dipole_pencil(scan, self%pix(:,1,1), psi(:,1,1), s_bufA)
-       !call tod%orb_dp%p%compute_orbital_dipole_pencil(scan, self%pix(:,1,2), psi(:,1,2), s_bufB)
-    end if
+    call tod%construct_dipole_template(scan, self%pix(:,:,1), self%psi(:,:,1), .true., s_bufA)
+    call tod%construct_dipole_template(scan, self%pix(:,:,2), self%psi(:,:,2), .true., s_bufB)
     do j = 1, self%ndet
        if (.not. tod%scans(scan)%d(j)%accept) cycle
-       self%s_orb(:,j) = (1.+tod%x_im(j))*s_bufA(:,j) - (1.-tod%x_im(j))*s_bufB(:,j)
-       self%s_tot(:,j) = self%s_tot(:,j) + self%s_orb(:,j)
+       self%s_orb(:,j)  = (1.+tod%x_im(j))*s_bufA(:,j)  - (1.-tod%x_im(j))*s_bufB(:,j)
+       self%s_totA(:,j) = self%s_totA(:,j) + s_bufA(:,j)
+       self%s_totB(:,j) = self%s_totB(:,j) + s_bufB(:,j)
+       self%s_tot(:,j)  = self%s_tot(:,j)  + self%s_orb(:,j)
     end do
+
 
     ! Construct zodical light template
     if (tod%subtract_zodi) then
@@ -349,6 +330,8 @@ contains
           call compute_zodi_template(tod%nside, self%pix(:,1:1,2), tod%scans(scan)%satpos, tod%nu_c(j:j), s_bufB)
           self%s_zodi(:,j) = (1.+tod%x_im(j))*s_bufA(:,j) - (1.-tod%x_im(j))*s_bufB(:,j)
           self%s_tot(:,j)  = self%s_tot(:,j) + self%s_zodi(:,j)
+          self%s_totA(:,j) = self%s_totA(:,j) + s_bufA(:,j)
+          self%s_totB(:,j) = self%s_totB(:,j) + s_bufB(:,j)
        end do
     else
        self%s_zodi = 0.
@@ -362,6 +345,8 @@ contains
           call tod%construct_sl_template(tod%slconv(3)%p, self%pix(:,1,2), self%psi(:,1,2), s_bufB(:,j), 0d0)
           self%s_sl(:,j)  = 2.*((1d0+tod%x_im(j))*s_bufA(:,j) - (1d0-tod%x_im(j))*s_bufB(:,j))
           self%s_tot(:,j) = self%s_tot(:,j) + self%s_sl(:,j)
+          self%s_totA(:,j) = self%s_totA(:,j) + 2.*s_bufA(:,j)
+          self%s_totB(:,j) = self%s_totB(:,j) + 2.*s_bufB(:,j)
        end do
     else
        self%s_sl = 0.
@@ -374,6 +359,8 @@ contains
           !self%s_mono(:,j) = tod%mono(j)
           self%s_mono(:,j) = 0.d0 ! Disabled for now
           self%s_tot(:,j)  = self%s_tot(:,j) + self%s_mono(:,j)
+          self%s_totA(:,j) = self%s_totA(:,j) + self%s_mono(:,j)
+          self%s_totB(:,j) = self%s_totB(:,j) + self%s_mono(:,j)
        end do
     else
        self%s_mono = 0.d0 
@@ -387,13 +374,13 @@ contains
 
   subroutine dealloc_scan_data(self)
     implicit none
-    class(scan_data), intent(inout) :: self    
+    class(comm_scandata), intent(inout) :: self    
 
     self%ntod = -1; self%ndet = -1; self%nhorn = -1
 
     ! Deallocate data structures
     deallocate(self%tod, self%n_corr, self%s_sl, self%s_sky)
-    deallocate(self%s_orb, self%s_tot, self%s_buf, self%mask)
+    deallocate(self%s_orb, self%s_tot, self%mask)
     deallocate(self%pix, self%psi, self%flag)
     if (allocated(self%s_sky_prop))  deallocate(self%s_sky_prop)
     if (allocated(self%s_bp_prop))   deallocate(self%s_bp_prop)
@@ -406,5 +393,229 @@ contains
 
   end subroutine dealloc_scan_data
 
+
+  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  !  Sampling drivers etc.
+  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+
+  ! Sample gain
+  ! Supported modes = {abscal, relcal, deltaG}
+  subroutine sample_calibration(tod, mode, handle, map_sky, procmask, procmask2)
+    implicit none
+    class(comm_tod),                              intent(inout) :: tod
+    character(len=*),                             intent(in)    :: mode
+    type(planck_rng),                             intent(inout) :: handle
+    real(sp),            dimension(0:,1:,1:,1:),  intent(in)    :: map_sky
+    real(sp),            dimension(0:),           intent(in)    :: procmask, procmask2
+
+    integer(i4b) :: i, j, ext(2), ierr
+    real(dp)     :: t1, t2
+    real(dp), allocatable, dimension(:)   :: A, b
+    real(sp), allocatable, dimension(:,:) :: s_invN, mask_lowres, s_buf
+    real(dp), allocatable, dimension(:,:) :: dipole_mod
+    type(comm_scandata) :: sd
+
+
+
+    if (tod%myid == 0) then
+       write(*,*) '   --> Sampling absolute calibration'
+    end if
+
+    if (trim(mode) == 'abscal' .or. trim(mode) == 'relcal') then
+       allocate(A(tod%ndet), b(tod%ndet))
+       A = 0.d0; b = 0.d0
+    else if (trim(mode) == 'deltaG') then
+       allocate(dipole_mod(tod%nscan_tot, tod%ndet))
+       dipole_mod = 0.d0
+    end if
+
+    do i = 1, tod%nscan
+       if (.not. any(tod%scans(i)%d%accept)) cycle
+       call wall_time(t1)
+
+       ! Prepare data
+       if (tod%nhorn == 1) then
+          call sd%init_singlehorn(tod, i, map_sky, procmask, procmask2)
+       else
+          call sd%init_differential(tod, i, map_sky, procmask, procmask2)
+       end if
+
+       ! Set up filtered calibration signal, conditional contribution and mask
+       call tod%downsample_tod(sd%s_orb(:,1), ext)
+       allocate(s_invN(ext(1):ext(2), tod%ndet))      ! s * invN
+       allocate(s_buf(sd%ntod, sd%ndet))
+       allocate(mask_lowres(ext(1):ext(2), tod%ndet))
+       do j = 1, tod%ndet
+          if (.not. tod%scans(i)%d(j)%accept) cycle
+          call tod%downsample_tod(sd%mask(:,j), ext, mask_lowres(:,j), threshold=0.9)
+          if (trim(mode) == 'abscal' .and. tod%orb_abscal) then
+             ! Calibrator = orbital dipole only
+             call tod%downsample_tod(sd%s_orb(:,j), ext, s_invN(:,j))
+          else
+             ! Calibratior = total signal
+             s_buf(:,j) = sd%s_tot(:,j)
+             call fill_all_masked(s_buf(:,j), sd%mask(:,j), sd%ntod, .false., real(tod%scans(i)%d(j)%sigma0, sp), handle, tod%scans(i)%chunk_num)
+             call tod%downsample_tod(s_buf(:,j), ext, s_invN(:,j))
+          end if
+       end do
+       call multiply_inv_N(tod, i, s_invN, sampfreq=tod%samprate_lowres, pow=0.5d0)
+
+       if (trim(mode) == 'abscal' .or. trim(mode) == 'relcal') then
+          ! Constant gain terms; accumulate contribution from this scan
+          do j = 1, tod%ndet
+             if (.not. tod%scans(i)%d(j)%accept) cycle
+             if (trim(mode) == 'abscal' .and. tod%orb_abscal) then
+                s_buf(:,j) = real(tod%gain0(0),sp) * (sd%s_tot(:,j) - sd%s_orb(:,j)) + &
+                     & real(tod%gain0(j) + tod%scans(i)%d(j)%dgain,sp) * sd%s_tot(:,j)
+             else
+                s_buf(:,j) = real(tod%gain0(j) + tod%scans(i)%d(j)%dgain,sp) * sd%s_tot(:,j)
+             end if
+             call accumulate_abscal(tod, i, sd%mask, s_buf, s_invN, s_invN, A, b, handle, .false., mask_lowres=mask_lowres)
+          end do
+       else
+          ! Time-variable gain terms
+          call calculate_gain_mean_std_per_scan(tod, i, s_invN, sd%mask, s_invN, sd%s_tot, handle, mask_lowres=mask_lowres)
+
+          do j = 1, tod%ndet
+             if (.not. tod%scans(i)%d(j)%accept) cycle
+             dipole_mod(tod%scanid(i),j) = masked_variance(sd%s_sky(:,j), sd%mask(:,j))
+          end do
+       end if
+
+       ! Clean up
+       call wall_time(t2)
+       tod%scans(i)%proctime   = tod%scans(i)%proctime   + t2-t1
+       tod%scans(i)%n_proctime = tod%scans(i)%n_proctime + 1
+       call sd%dealloc
+       deallocate(s_invN, s_buf, mask_lowres)
+    end do
+
+    ! Perform sampling operations
+    if (trim(mode) == 'abscal') then
+       call sample_abscal_from_orbital(tod, handle, A, b)
+    else if (trim(mode) == 'relcal') then
+       call sample_relcal(tod, handle, A, b)
+    else if (trim(mode) == 'deltaG') then
+       call mpi_allreduce(mpi_in_place, dipole_mod, size(dipole_mod), MPI_DOUBLE_PRECISION, MPI_SUM, tod%info%comm, ierr)
+       call sample_smooth_gain(tod, handle, dipole_mod)
+    end if
+
+    ! Clean up
+    if (allocated(A))          deallocate(A)
+    if (allocated(b))          deallocate(b)
+    if (allocated(dipole_mod)) deallocate(dipole_mod)
+
+  end subroutine sample_calibration
+
+  subroutine remove_bad_data(tod, scan, flag)
+    implicit none
+    class(comm_tod),                   intent(inout) :: tod
+    integer(i4b),    dimension(1:,1:), intent(in)    :: flag
+    integer(i4b),                      intent(in)    :: scan
+
+    integer(i4b) :: j, ntod, ndet
+    
+    ntod = size(flag,1)
+    ndet = size(flag,2)
+    do j = 1, ndet
+       if (.not. tod%scans(scan)%d(j)%accept) cycle
+       if (count(iand(flag(:,j),tod%flag0) .ne. 0) > 0.1*ntod) then    ! Discard scans with less than 10% good data
+          tod%scans(scan)%d(j)%accept = .false.
+       else if (abs(tod%scans(scan)%d(j)%chisq) > tod%chisq_threshold .or. &  ! Discard scans with high chisq or NaNs
+            & isNaN(tod%scans(scan)%d(j)%chisq)) then
+          write(*,fmt='(a,i8,i5,a,f12.1)') 'Reject scan, det = ', &
+               & tod%scanid(scan), j, ', chisq = ', tod%scans(scan)%d(j)%chisq
+          tod%scans(scan)%d(j)%accept = .false.
+       end if
+    end do
+    if (any(.not. tod%scans(scan)%d%accept)) tod%scans(scan)%d%accept = .false. ! Do we actually want this..?
+    do j = 1, ndet
+       if (.not. tod%scans(scan)%d(j)%accept) tod%scans(scan)%d(tod%partner(j))%accept = .false.
+    end do
+
+  end subroutine remove_bad_data
+
+  subroutine compute_chisq_abs_bp(tod, scan, sd, chisq)
+    implicit none
+    class(comm_tod),                       intent(inout) :: tod
+    integer(i4b),                          intent(in)    :: scan
+    type(comm_scandata),                   intent(in)    :: sd
+    real(dp),            dimension(:,:),   intent(inout) :: chisq
+
+    integer(i4b) :: j, k
+    real(sp), allocatable, dimension(:,:) :: s_buf
+
+    allocate(s_buf(sd%ntod,sd%ndet))
+    do j = 1, tod%ndet
+       if (.not. tod%scans(scan)%d(j)%accept) cycle
+       s_buf(:,j) =  sd%s_sl(:,j) + sd%s_orb(:,j)
+       call tod%compute_chisq(scan, j, sd%mask2(:,j), sd%s_sky(:,j), &
+            & s_buf(:,j), sd%n_corr(:,j), absbp=.true.)
+       chisq(j,1) = chisq(j,1) + tod%scans(scan)%d(j)%chisq_prop
+       do k = 2, size(sd%s_sky_prop)
+          call tod%compute_chisq(scan, j, sd%mask2(:,j), sd%s_sky_prop(:,j,k), &
+               & s_buf(:,j), sd%n_corr(:,j), absbp=.true.)
+          chisq(j,k) = chisq(j,k) + tod%scans(scan)%d(j)%chisq_prop
+       end do
+    end do
+    deallocate(s_buf)
+
+  end subroutine compute_chisq_abs_bp
+
+  subroutine compute_calibrated_data(tod, scan, sd, d_calib)
+    implicit none
+    class(comm_tod),                       intent(in)   :: tod
+    integer(i4b),                          intent(in)   :: scan
+    type(comm_scandata),                   intent(in)   :: sd
+    real(sp),            dimension(:,:,:), intent(out)  :: d_calib
+
+    integer(i4b) :: j, nout
+    real(sp)     :: inv_gain
+
+    nout = size(d_calib,1)
+    do j = 1, sd%ndet
+       if (.not. tod%scans(scan)%d(j)%accept) cycle
+       inv_gain = 1.0 / real(tod%scans(scan)%d(j)%gain,sp)
+       d_calib(1,:,j) = (tod%scans(scan)%d(j)%tod - sd%n_corr(:,j)) * inv_gain - sd%s_tot(:,j) + sd%s_sky(:,j) - sd%s_bp(:,j)
+       if (nout > 1) d_calib(2,:,j) = d_calib(1,:,j) - sd%s_sky(:,j) + sd%s_bp(:,j)              ! residual
+       if (nout > 2) d_calib(3,:,j) = (sd%n_corr(:,j) - sum(sd%n_corr(:,j)/sd%ntod)) * inv_gain  ! ncorr
+       if (nout > 3) d_calib(4,:,j) = sd%s_bp(:,j)                                               ! bandpass
+       if (nout > 4) d_calib(5,:,j) = sd%s_orb(:,j)                                              ! orbital dipole
+       if (nout > 5) d_calib(6,:,j) = sd%s_sl(:,j)                                               ! sidelobes
+       if (nout > 6) d_calib(7,:,j) = sd%s_zodi(:,j)                                             ! zodi
+    end do
+
+  end subroutine compute_calibrated_data
+
+  subroutine distribute_sky_maps(tod, map_in, scale, map_out)
+    implicit none
+    class(comm_tod),                       intent(in)     :: tod
+    type(map_ptr), dimension(1:,1:),       intent(inout)  :: map_in       ! (ndet,ndelta)    
+    real(sp),                              intent(in)     :: scale
+    real(sp),      dimension(1:,1:,0:,1:), intent(out)    :: map_out
+
+    integer(i4b) :: i, j, k, l, npix, nmaps
+    real(dp),     allocatable, dimension(:,:) :: m_buf
+
+    npix  = map_in(1,1)%p%info%npix
+    nmaps = map_in(1,1)%p%info%nmaps
+    allocate(m_buf(0:npix-1,nmaps))
+    do j = 1, size(map_in,2)
+       do i = 1, size(map_in,1)
+          map_in(i,j)%p%map = scale * map_in(i,j)%p%map ! unit conversion
+          call map_in(i,j)%p%bcast_fullsky_map(m_buf)
+          do k = 1, tod%nobs
+             map_out(:,k,i,j) = m_buf(tod%ind2pix(k),:)
+          end do
+       end do
+       do k = 1, tod%nobs
+          do l = 1, tod%nmaps
+             map_out(l,k,0,j) = sum(map_out(l,k,1:tod%ndet,j))/tod%ndet
+          end do
+       end do
+    end do
+    deallocate(m_buf)
+
+  end subroutine distribute_sky_maps
 
 end module comm_tod_driver_mod

--- a/commander3/src/comm_tod_driver_mod.f90
+++ b/commander3/src/comm_tod_driver_mod.f90
@@ -17,24 +17,28 @@ module comm_tod_driver_mod
      integer(i4b) :: ntod, ndet, nhorn, ndelta
      real(sp),     allocatable, dimension(:,:)     :: tod        ! Raw data
      real(sp),     allocatable, dimension(:,:)     :: n_corr     ! Correlated noise in V
-     real(sp),     allocatable, dimension(:,:,:)   :: s_sl       ! Sidelobe correction
-     real(sp),     allocatable, dimension(:,:,:)   :: s_sky      ! Stationary sky signal
-     real(sp),     allocatable, dimension(:,:,:,:) :: s_sky_prop ! Stationary sky signal proposal for bandpass sampling
-     real(sp),     allocatable, dimension(:,:,:)   :: s_orb      ! Orbital dipole
+     real(sp),     allocatable, dimension(:,:)     :: s_sl       ! Sidelobe correction
+     real(sp),     allocatable, dimension(:,:)     :: s_sky      ! Stationary sky signal
+     real(sp),     allocatable, dimension(:,:,:)   :: s_sky_prop ! Stationary sky signal proposal for bandpass sampling
+     real(sp),     allocatable, dimension(:,:)     :: s_orb      ! Orbital dipole
      real(sp),     allocatable, dimension(:,:)     :: s_mono     ! Detector monopole correction 
-     real(sp),     allocatable, dimension(:,:,:)   :: s_bp       ! Bandpass correction
-     real(sp),     allocatable, dimension(:,:,:,:) :: s_bp_prop  ! Bandpass correction proposal     
-     real(sp),     allocatable, dimension(:,:,:)   :: s_zodi     ! Zodiacal light
-     real(sp),     allocatable, dimension(:,:,:)   :: s_tot      ! Total signal
+     real(sp),     allocatable, dimension(:,:)     :: s_bp       ! Bandpass correction
+     real(sp),     allocatable, dimension(:,:,:)   :: s_bp_prop  ! Bandpass correction proposal     
+     real(sp),     allocatable, dimension(:,:)     :: s_zodi     ! Zodiacal light
+     real(sp),     allocatable, dimension(:,:)     :: s_tot      ! Total signal
      real(sp),     allocatable, dimension(:,:)     :: mask       ! TOD mask (flags + main processing mask)
      real(sp),     allocatable, dimension(:,:)     :: mask2      ! Small TOD mask, for bandpass sampling
      integer(i4b), allocatable, dimension(:,:,:)   :: pix        ! Discretized pointing 
      integer(i4b), allocatable, dimension(:,:,:)   :: psi        ! Discretized polarization angle
      integer(i4b), allocatable, dimension(:,:)     :: flag       ! Quality flags
      real(sp),     allocatable, dimension(:,:)     :: s_buf      ! Buffer
+
+     real(sp),     allocatable, dimension(:,:)     :: s_totA     ! Total signal, horn A (differential only)
+     real(sp),     allocatable, dimension(:,:)     :: s_totB     ! Total signal, horn B (differential only)
    contains
-     procedure  :: initialize => init_scan_data
-     procedure  :: dealloc    => dealloc_scan_data
+     procedure  :: init_singlehorn   => init_scan_data_singlehorn
+     procedure  :: init_differential => init_scan_data_differential
+     procedure  :: dealloc           => dealloc_scan_data
   end type scan_data
 
 
@@ -44,8 +48,8 @@ contains
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
   !  Scan data routines
   !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
-  subroutine init_scan_data(self, tod, scan, map_sky, sprocmask, sprocmask2, &
-       & init_s_bp, init_s_bp_prop, init_s_sky_prop)
+  subroutine init_scan_data_singlehorn(self, tod, scan, map_sky, sprocmask, sprocmask2, &
+       & init_s_bp, init_s_bp_prop, init_s_sky_prop, symmetrize_flags)
     implicit none
     class(scan_data),                      intent(inout)          :: self    
     class(comm_tod),                       intent(inout)          :: tod
@@ -56,9 +60,15 @@ contains
     logical(lgt),                          intent(in),   optional :: init_s_bp
     logical(lgt),                          intent(in),   optional :: init_s_bp_prop
     logical(lgt),                          intent(in),   optional :: init_s_sky_prop
+    logical(lgt),                          intent(in),   optional :: symmetrize_flags
 
     integer(i4b) :: j, k, ndelta
-    logical(lgt) :: init_s_bp_, init_s_bp_prop_, init_s_sky_prop_
+    logical(lgt) :: init_s_bp_, init_s_bp_prop_, init_s_sky_prop_, symmetrize_flags_
+
+    if (tod%nhorn /= 1) then
+       write(*,*) 'Error: init_scan_data_singlehorn only applicable for 1-horn experiments'
+       stop
+    end if
 
     init_s_bp_ = .false.; if (present(init_s_bp)) init_s_bp_ = init_s_bp
     init_s_sky_prop_ = .false.; if (present(init_s_sky_prop)) init_s_sky_prop_ = init_s_sky_prop
@@ -67,6 +77,7 @@ contains
        init_s_bp_prop_ = init_s_bp_prop
        init_s_sky_prop_ = init_s_sky_prop
     end if
+    symmetrize_flags_ = .false.; if (present(symmetrize_flags)) symmetrize_flags_ = symmetrize_flags
 
     self%ntod   = tod%scans(scan)%ntod
     self%ndet   = tod%ndet
@@ -76,21 +87,21 @@ contains
     ! Allocate data structures
     allocate(self%tod(self%ntod, self%ndet))
     allocate(self%n_corr(self%ntod, self%ndet))
-    allocate(self%s_sl(self%ntod, self%ndet, self%nhorn))
-    allocate(self%s_sky(self%ntod, self%ndet, self%nhorn))
-    allocate(self%s_bp(self%ntod, self%ndet, self%nhorn))
-    allocate(self%s_orb(self%ntod, self%ndet, self%nhorn))
-    allocate(self%s_tot(self%ntod, self%ndet, self%nhorn))
+    allocate(self%s_sl(self%ntod, self%ndet))
+    allocate(self%s_sky(self%ntod, self%ndet))
+    allocate(self%s_bp(self%ntod, self%ndet))
+    allocate(self%s_orb(self%ntod, self%ndet))
+    allocate(self%s_tot(self%ntod, self%ndet))
     allocate(self%s_buf(self%ntod, self%ndet))
     allocate(self%mask(self%ntod, self%ndet))
     allocate(self%pix(self%ntod, self%ndet, self%nhorn))
     allocate(self%psi(self%ntod, self%ndet, self%nhorn))
     allocate(self%flag(self%ntod, self%ndet))
-    if (init_s_sky_prop_)   allocate(self%s_sky_prop(self%ntod, self%ndet, self%nhorn, 2:self%ndelta))
-    if (init_s_bp_prop_)    allocate(self%s_bp_prop(self%ntod, self%ndet, self%nhorn, 2:self%ndelta))
+    if (init_s_sky_prop_)   allocate(self%s_sky_prop(self%ntod, self%ndet, 2:self%ndelta))
+    if (init_s_bp_prop_)    allocate(self%s_bp_prop(self%ntod, self%ndet, 2:self%ndelta))
     if (init_s_sky_prop_)   allocate(self%mask2(self%ntod, self%ndet))
     if (tod%sample_mono)    allocate(self%s_mono(self%ntod, self%ndet))
-    if (tod%subtract_zodi)  allocate(self%s_zodi(self%ntod, self%ndet, self%nhorn))
+    if (tod%subtract_zodi)  allocate(self%s_zodi(self%ntod, self%ndet))
 
     ! Decompress pointing, psi and flags for current scan
     do j = 1, self%ndet
@@ -98,7 +109,7 @@ contains
        call tod%decompress_pointing_and_flags(scan, j, self%pix(:,j,:), &
             & self%psi(:,j,:), self%flag(:,j))
     end do
-    call tod%symmetrize_flags(self%flag)
+    if (symmetrize_flags_) call tod%symmetrize_flags(self%flag)
     
     ! Prepare TOD
     do j = 1, self%ndet
@@ -111,30 +122,26 @@ contains
     end do
 
     ! Construct sky signal template
-    do k = 1, self%nhorn
-       if (init_s_bp_) then
-          call project_sky(tod, map_sky(:,:,:,1), self%pix(:,:,k:k), self%psi(:,:,k:k), self%flag, &
-               & sprocmask%a, scan, self%s_sky(:,:,k), self%mask, s_bp=self%s_bp(:,:,k))
-       else
-          call project_sky(tod, map_sky(:,:,:,1), self%pix(:,:,k:k), self%psi(:,:,k:k), self%flag, &
-               & sprocmask%a, scan, self%s_sky(:,:,k), self%mask)
-       end if
-    end do
+    if (init_s_bp_) then
+       call project_sky(tod, map_sky(:,:,:,1), self%pix(:,:,1), self%psi(:,:,1), self%flag, &
+            & sprocmask%a, scan, self%s_sky, self%mask, s_bp=self%s_bp)
+    else
+       call project_sky(tod, map_sky(:,:,:,1), self%pix(:,:,1), self%psi(:,:,1), self%flag, &
+            & sprocmask%a, scan, self%s_sky, self%mask)
+    end if
 
     ! Set up (optional) bandpass sampling quantities (s_sky_prop, mask2 and bp_prop)
-    do k = 1, self%nhorn
-       if (init_s_bp_prop_) then
-          do j = 2, size(map_sky,4)
-             call project_sky(tod, map_sky(:,:,:,j), self%pix(:,:,k:k), self%psi(:,:,k:k), self%flag, &
-                  & sprocmask2%a, scan, self%s_sky_prop(:,:,k,j), self%mask2, s_bp=self%s_bp_prop(:,:,k,j))
-          end do
-       else if (init_s_sky_prop_) then
-          do j = 2, size(map_sky,4)
-             call project_sky(tod, map_sky(:,:,:,j), self%pix(:,:,k:k), self%psi(:,:,k:k), self%flag, &
-                  & sprocmask2%a, scan, self%s_sky_prop(:,:,k,j), self%mask2)
-          end do
-       end if
-    end do
+    if (init_s_bp_prop_) then
+       do j = 2, size(map_sky,4)
+          call project_sky(tod, map_sky(:,:,:,j), self%pix(:,:,1), self%psi(:,:,1), self%flag, &
+               & sprocmask2%a, scan, self%s_sky_prop(:,:,j), self%mask2, s_bp=self%s_bp_prop(:,:,j))
+       end do
+    else if (init_s_sky_prop_) then
+       do j = 2, size(map_sky,4)
+          call project_sky(tod, map_sky(:,:,:,j), self%pix(:,:,1), self%psi(:,:,1), self%flag, &
+               & sprocmask2%a, scan, self%s_sky_prop(:,:,j), self%mask2)
+       end do
+    end if
 
     ! Perform sanity tests
     do j = 1, self%ndet
@@ -144,36 +151,29 @@ contains
     end do
     
     ! Construct orbital dipole template
-    do k = 1, tod%nhorn
-       if (tod%orb_4pi_beam) then
-          !call tod%orb_dp%p%compute_orbital_dipole_4pi(scan, self%pix(:,:,k), self%psi(:,:,k), self%s_orb(:,:,k))
-       else
-          ! Duncan: Fix units on your side to get rid of the 1d3 scaling factor
-          !call tod%orb_dp%p%compute_orbital_dipole_pencil(scan, self%pix(:,:,k), self%psi(:,:,k), self%s_orb(:,:,k))
-       end if
-    end do
+    if (tod%orb_4pi_beam) then
+       !call tod%orb_dp%p%compute_orbital_dipole_4pi(scan, self%pix(:,:,1), self%psi(:,:,1), self%s_orb(:,:,1))
+    else
+       !call tod%orb_dp%p%compute_orbital_dipole_pencil(scan, self%pix(:,:,1), self%psi(:,:,1), self%s_orb(:,:,1))
+    end if
 
     ! Construct zodical light template
     if (tod%subtract_zodi) then
-       do k = 1, self%nhorn
-          call compute_zodi_template(tod%nside, self%pix(:,:,k), tod%scans(scan)%satpos, tod%nu_c, self%s_zodi(:,:,k))
-       end do
+       call compute_zodi_template(tod%nside, self%pix(:,:,1), tod%scans(scan)%satpos, tod%nu_c, self%s_zodi)
     end if
 
     ! Construct sidelobe template
     if (tod%correct_sl) then
        do j = 1, self%ndet
           if (.not. tod%scans(scan)%d(j)%accept) cycle
-          do k = 1, self%nhorn
-             call tod%construct_sl_template(tod%slconv(j)%p, &
-                  & self%pix(:,j,1), self%psi(:,j,1), self%s_sl(:,j,k), tod%polang(j))
-             self%s_sl(:,j,k) = 2.d0 * self%s_sl(:,j,k) ! Scaling by a factor of 2, by comparison with LevelS. Should be understood
-          end do
+          call tod%construct_sl_template(tod%slconv(j)%p, &
+               & self%pix(:,j,1), self%psi(:,j,1), self%s_sl(:,j), tod%polang(j))
+          self%s_sl(:,j) = 2.d0 * self%s_sl(:,j) ! Scaling by a factor of 2, by comparison with LevelS. Should be understood
        end do
     else
        do j = 1, self%ndet
           if (.not. tod%scans(scan)%d(j)%accept) cycle
-          self%s_sl(:,j,:) = 0.
+          self%s_sl(:,j) = 0.
        end do
     end if
 
@@ -189,13 +189,201 @@ contains
     ! Construct total sky signal
     do j = 1, self%ndet
        if (.not. tod%scans(scan)%d(j)%accept) cycle
-       self%s_tot(:,j,:) = self%s_sky(:,j,:) + self%s_sl(:,j,:) + self%s_orb(:,j,:)
-       do k = 1, self%nhorn
-          if (tod%sample_mono) self%s_tot(:,j,k) = self%s_tot(:,j,k) + self%s_mono(:,j)
-       end do
+       self%s_tot(:,j) = self%s_sky(:,j) + self%s_sl(:,j) + self%s_orb(:,j)
+       if (tod%sample_mono) self%s_tot(:,j) = self%s_tot(:,j) + self%s_mono(:,j)
     end do
 
-  end subroutine init_scan_data
+  end subroutine init_scan_data_singlehorn
+
+
+  subroutine init_scan_data_differential(self, tod, scan, map_sky, procmask, procmask2, &
+       & init_s_bp, init_s_bp_prop, init_s_sky_prop, symmetrize_flags)
+    implicit none
+    class(scan_data),                      intent(inout)          :: self    
+    class(comm_tod),                       intent(inout)          :: tod
+    integer(i4b),                          intent(in)             :: scan
+    real(sp),          dimension(:,:,:,:), intent(in)             :: map_sky
+    integer(i4b),      dimension(0:),      intent(in)             :: procmask
+    integer(i4b),      dimension(0:),      intent(in)             :: procmask2
+    logical(lgt),                          intent(in),   optional :: init_s_bp
+    logical(lgt),                          intent(in),   optional :: init_s_bp_prop
+    logical(lgt),                          intent(in),   optional :: init_s_sky_prop
+    logical(lgt),                          intent(in),   optional :: symmetrize_flags
+
+    integer(i4b) :: j, k, ndelta
+    logical(lgt) :: init_s_bp_, init_s_bp_prop_, init_s_sky_prop_, symmetrize_flags_
+    real(sp),     allocatable, dimension(:,:)     :: s_bufA, s_bufB, s_buf2A, s_buf2B      ! Buffer
+
+    if (tod%nhorn /= 2) then
+       write(*,*) 'Error: init_scan_data_differential only applicable for 2-horn experiments'
+       stop
+    end if
+
+    if (present(symmetrize_flags)) then
+       write(*,*) 'Error: init_scan_daa_differential does not support symmetrize_flags'
+       stop
+    end if
+
+    init_s_bp_ = .false.; if (present(init_s_bp)) init_s_bp_ = init_s_bp
+    init_s_sky_prop_ = .false.; if (present(init_s_sky_prop)) init_s_sky_prop_ = init_s_sky_prop
+    init_s_bp_prop_ = .false.
+    if (present(init_s_bp_prop)) then
+       init_s_bp_prop_ = init_s_bp_prop
+       init_s_sky_prop_ = init_s_sky_prop
+    end if
+    symmetrize_flags_ = .false.; if (present(symmetrize_flags)) symmetrize_flags_ = symmetrize_flags
+
+    self%ntod   = tod%scans(scan)%ntod
+    self%ndet   = tod%ndet
+    self%nhorn  = tod%nhorn
+    self%ndelta = 0; if (present(init_s_sky_prop)) self%ndelta = size(map_sky,4)
+
+    ! Allocate data structures
+    allocate(self%tod(self%ntod, self%ndet))
+    allocate(self%n_corr(self%ntod, self%ndet))
+    allocate(self%s_sl(self%ntod, self%ndet))
+    allocate(self%s_sky(self%ntod, self%ndet))
+    allocate(self%s_bp(self%ntod, self%ndet))
+    allocate(self%s_orb(self%ntod, self%ndet))
+    allocate(self%s_tot(self%ntod, self%ndet))
+    allocate(self%s_totA(self%ntod, self%ndet))
+    allocate(self%s_totB(self%ntod, self%ndet))
+    allocate(self%s_buf(self%ntod, self%ndet))
+    allocate(self%mask(self%ntod, self%ndet))
+    allocate(self%pix(self%ntod, 1, self%nhorn))
+    allocate(self%psi(self%ntod, 1, self%nhorn))
+    allocate(self%flag(self%ntod, 1))
+    if (init_s_sky_prop_)   allocate(self%s_sky_prop(self%ntod, self%ndet, 2:self%ndelta))
+    if (init_s_bp_prop_)    allocate(self%s_bp_prop(self%ntod, self%ndet, 2:self%ndelta))
+    if (init_s_sky_prop_)   allocate(self%mask2(self%ntod, self%ndet))
+    if (tod%sample_mono)    allocate(self%s_mono(self%ntod, self%ndet))
+    if (tod%subtract_zodi)  allocate(self%s_zodi(self%ntod, self%ndet))
+    self%s_totA = 0.
+    self%s_totB = 0.
+
+    allocate(s_bufA(self%ntod, self%ndet))
+    allocate(s_bufB(self%ntod, self%ndet))
+    allocate(s_buf2A(self%ntod, self%ndet))
+    allocate(s_buf2B(self%ntod, self%ndet))
+
+    ! Decompress pointing, psi and flags for current scan
+    call tod%decompress_pointing_and_flags(scan, j, self%pix(:,1,:), &
+            & self%psi(:,1,:), self%flag(:,1))
+    
+    ! Prepare TOD
+    do j = 1, self%ndet
+       if (.not. tod%scans(scan)%d(j)%accept) cycle
+       if (tod%compressed_tod) then
+          !call tod%decompress_tod(scan, j, self%tod(:,j))
+       else
+          self%tod(:,j) = tod%scans(scan)%d(j)%tod
+       end if
+    end do
+
+    ! Construct sky signal template
+    if (init_s_bp_) then
+       call project_sky_differential(tod, map_sky(:,:,:,1), self%pix(:,1,:), self%psi(:,1,:), self%flag(:,1), &
+            & procmask, scan, s_bufA, s_bufB, self%mask, s_bpA=s_buf2A, s_bpB=s_buf2B)
+    else
+       call project_sky_differential(tod, map_sky(:,:,:,1), self%pix(:,1,:), self%psi(:,1,:), self%flag(:,1), &
+            & procmask, scan, s_bufA, s_bufB, self%mask)
+    end if
+    do j = 1, self%ndet
+       if (.not. tod%scans(scan)%d(j)%accept) cycle
+       self%s_sky(:,j)  = (1.+tod%x_im(j))*s_bufA(:,j)  - (1.-tod%x_im(j))*s_bufB(:,j)
+       self%s_totA(:,j) = self%s_totA(:,j) + s_bufA(:,j)
+       self%s_totB(:,j) = self%s_totB(:,j) + s_bufB(:,j)
+       self%s_tot(:,j)  = self%s_tot(:,j)  + self%s_sky(:,j)
+       if (init_s_bp_) self%s_bp(:,j)  = (1.+tod%x_im(j))*s_buf2A(:,j) - (1.-tod%x_im(j))*s_buf2B(:,j)
+    end do
+
+    ! Set up (optional) bandpass sampling quantities (s_sky_prop, mask2 and bp_prop)
+    if (init_s_bp_prop_) then
+       do k = 2, size(map_sky,4)
+          call project_sky_differential(tod, map_sky(:,:,:,k), self%pix(:,1,:), self%psi(:,1,:), self%flag(:,1), &
+               & procmask, scan, s_bufA, s_bufB, self%mask, s_bpA=s_buf2A, s_bpB=s_buf2B)
+          do j = 1, self%ndet
+             if (.not. tod%scans(scan)%d(j)%accept) cycle
+             self%s_sky_prop(:,j,k) = (1.+tod%x_im(j))*s_bufA(:,j)  - (1.-tod%x_im(j))*s_bufB(:,j)
+             if (init_s_bp_) self%s_bp_prop(:,j,k)  = (1.+tod%x_im(j))*s_buf2A(:,j) - (1.-tod%x_im(j))*s_buf2B(:,j)
+          end do
+       end do
+    else if (init_s_sky_prop_) then
+       do k = 2, size(map_sky,4)
+          call project_sky_differential(tod, map_sky(:,:,:,k), self%pix(:,1,:), self%psi(:,1,:), self%flag(:,1), &
+               & procmask, scan, s_bufA, s_bufB, self%mask)
+          do j = 1, self%ndet
+             if (.not. tod%scans(scan)%d(j)%accept) cycle
+             self%s_sky_prop(:,j,k) = (1.+tod%x_im(j))*s_bufA(:,j) - (1.-tod%x_im(j))*s_bufB(:,j)
+          end do
+       end do
+    end if
+
+    ! Perform sanity tests
+    do j = 1, self%ndet
+       if (.not. tod%scans(scan)%d(j)%accept) cycle
+       if (all(self%mask(:,j) == 0)) tod%scans(scan)%d(j)%accept = .false.
+       if (tod%scans(scan)%d(j)%sigma0 <= 0.d0) tod%scans(scan)%d(j)%accept = .false.
+    end do
+    
+    ! Construct orbital dipole template
+    if (tod%orb_4pi_beam) then
+       !call tod%orb_dp%p%compute_orbital_dipole_4pi(scan, self%pix(:,1,1), psi(:,1,1), s_bufA)
+       !call tod%orb_dp%p%compute_orbital_dipole_4pi(scan, self%pix(:,1,2), psi(:,1,2), s_bufB)
+    else
+       ! Duncan: Fix units on your side to get rid of the 1d3 scaling factor
+       !call tod%orb_dp%p%compute_orbital_dipole_pencil(scan, self%pix(:,1,1), psi(:,1,1), s_bufA)
+       !call tod%orb_dp%p%compute_orbital_dipole_pencil(scan, self%pix(:,1,2), psi(:,1,2), s_bufB)
+    end if
+    do j = 1, self%ndet
+       if (.not. tod%scans(scan)%d(j)%accept) cycle
+       self%s_orb(:,j) = (1.+tod%x_im(j))*s_bufA(:,j) - (1.-tod%x_im(j))*s_bufB(:,j)
+       self%s_tot(:,j) = self%s_tot(:,j) + self%s_orb(:,j)
+    end do
+
+    ! Construct zodical light template
+    if (tod%subtract_zodi) then
+       do j = 1, self%ndet
+          if (.not. tod%scans(scan)%d(j)%accept) cycle
+          call compute_zodi_template(tod%nside, self%pix(:,1:1,1), tod%scans(scan)%satpos, tod%nu_c(j:j), s_bufA)
+          call compute_zodi_template(tod%nside, self%pix(:,1:1,2), tod%scans(scan)%satpos, tod%nu_c(j:j), s_bufB)
+          self%s_zodi(:,j) = (1.+tod%x_im(j))*s_bufA(:,j) - (1.-tod%x_im(j))*s_bufB(:,j)
+          self%s_tot(:,j)  = self%s_tot(:,j) + self%s_zodi(:,j)
+       end do
+    else
+       self%s_zodi = 0.
+    end if
+
+    ! Construct sidelobe template
+    if (tod%correct_sl) then
+       do j = 1, self%ndet
+          if (.not. tod%scans(scan)%d(j)%accept) cycle
+          call tod%construct_sl_template(tod%slconv(1)%p, self%pix(:,1,1), self%psi(:,1,1), s_bufA(:,j), 0d0)
+          call tod%construct_sl_template(tod%slconv(3)%p, self%pix(:,1,2), self%psi(:,1,2), s_bufB(:,j), 0d0)
+          self%s_sl(:,j)  = 2.*((1d0+tod%x_im(j))*s_bufA(:,j) - (1d0-tod%x_im(j))*s_bufB(:,j))
+          self%s_tot(:,j) = self%s_tot(:,j) + self%s_sl(:,j)
+       end do
+    else
+       self%s_sl = 0.
+    end if
+
+    ! Construct monopole correction template
+    if (tod%sample_mono) then
+       do j = 1, self%ndet
+          if (.not. tod%scans(scan)%d(j)%accept) cycle
+          !self%s_mono(:,j) = tod%mono(j)
+          self%s_mono(:,j) = 0.d0 ! Disabled for now
+          self%s_tot(:,j)  = self%s_tot(:,j) + self%s_mono(:,j)
+       end do
+    else
+       self%s_mono = 0.d0 
+    end if
+
+    ! Clean-up
+    deallocate(s_bufA, s_bufB, s_buf2A, s_buf2B)
+
+  end subroutine init_scan_data_differential
+
 
   subroutine dealloc_scan_data(self)
     implicit none
@@ -213,6 +401,8 @@ contains
     if (allocated(self%s_mono))      deallocate(self%s_mono)
     if (allocated(self%mask2))       deallocate(self%mask2)
     if (allocated(self%s_zodi))      deallocate(self%s_zodi)
+    if (allocated(self%s_totA))      deallocate(self%s_totA)
+    if (allocated(self%s_totB))      deallocate(self%s_totB)
 
   end subroutine dealloc_scan_data
 

--- a/commander3/src/comm_tod_driver_mod.f90
+++ b/commander3/src/comm_tod_driver_mod.f90
@@ -1,0 +1,220 @@
+module comm_tod_driver_mod
+  use comm_tod_mod
+  use comm_tod_gain_mod
+  use comm_tod_noise_mod
+  use comm_tod_pointing_mod
+  use comm_tod_bandpass_mod
+  use comm_tod_orbdipole_mod
+  use comm_tod_simulations_mod
+  use comm_tod_mapmaking_mod
+  use comm_zodi_mod
+  use comm_shared_arr_mod
+  implicit none
+
+
+  ! Class for uncompressed data for a given scan
+  type :: scan_data
+     integer(i4b) :: ntod, ndet, nhorn, ndelta
+     real(sp),     allocatable, dimension(:,:)     :: tod        ! Raw data
+     real(sp),     allocatable, dimension(:,:)     :: n_corr     ! Correlated noise in V
+     real(sp),     allocatable, dimension(:,:,:)   :: s_sl       ! Sidelobe correction
+     real(sp),     allocatable, dimension(:,:,:)   :: s_sky      ! Stationary sky signal
+     real(sp),     allocatable, dimension(:,:,:,:) :: s_sky_prop ! Stationary sky signal proposal for bandpass sampling
+     real(sp),     allocatable, dimension(:,:,:)   :: s_orb      ! Orbital dipole
+     real(sp),     allocatable, dimension(:,:)     :: s_mono     ! Detector monopole correction 
+     real(sp),     allocatable, dimension(:,:,:)   :: s_bp       ! Bandpass correction
+     real(sp),     allocatable, dimension(:,:,:,:) :: s_bp_prop  ! Bandpass correction proposal     
+     real(sp),     allocatable, dimension(:,:,:)   :: s_zodi     ! Zodiacal light
+     real(sp),     allocatable, dimension(:,:,:)   :: s_tot      ! Total signal
+     real(sp),     allocatable, dimension(:,:)     :: mask       ! TOD mask (flags + main processing mask)
+     real(sp),     allocatable, dimension(:,:)     :: mask2      ! Small TOD mask, for bandpass sampling
+     integer(i4b), allocatable, dimension(:,:,:)   :: pix        ! Discretized pointing 
+     integer(i4b), allocatable, dimension(:,:,:)   :: psi        ! Discretized polarization angle
+     integer(i4b), allocatable, dimension(:,:)     :: flag       ! Quality flags
+     real(sp),     allocatable, dimension(:,:)     :: s_buf      ! Buffer
+   contains
+     procedure  :: initialize => init_scan_data
+     procedure  :: dealloc    => dealloc_scan_data
+  end type scan_data
+
+
+contains
+
+
+  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  !  Scan data routines
+  !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
+  subroutine init_scan_data(self, tod, scan, map_sky, sprocmask, sprocmask2, &
+       & init_s_bp, init_s_bp_prop, init_s_sky_prop)
+    implicit none
+    class(scan_data),                      intent(inout)          :: self    
+    class(comm_tod),                       intent(inout)          :: tod
+    integer(i4b),                          intent(in)             :: scan
+    real(sp),          dimension(:,:,:,:), intent(in)             :: map_sky
+    type(shared_1d_int),                   intent(in)             :: sprocmask
+    type(shared_1d_int),                   intent(in)             :: sprocmask2
+    logical(lgt),                          intent(in),   optional :: init_s_bp
+    logical(lgt),                          intent(in),   optional :: init_s_bp_prop
+    logical(lgt),                          intent(in),   optional :: init_s_sky_prop
+
+    integer(i4b) :: j, k, ndelta
+    logical(lgt) :: init_s_bp_, init_s_bp_prop_, init_s_sky_prop_
+
+    init_s_bp_ = .false.; if (present(init_s_bp)) init_s_bp_ = init_s_bp
+    init_s_sky_prop_ = .false.; if (present(init_s_sky_prop)) init_s_sky_prop_ = init_s_sky_prop
+    init_s_bp_prop_ = .false.
+    if (present(init_s_bp_prop)) then
+       init_s_bp_prop_ = init_s_bp_prop
+       init_s_sky_prop_ = init_s_sky_prop
+    end if
+
+    self%ntod   = tod%scans(scan)%ntod
+    self%ndet   = tod%ndet
+    self%nhorn  = tod%nhorn
+    self%ndelta = 0; if (present(init_s_sky_prop)) self%ndelta = size(map_sky,4)
+
+    ! Allocate data structures
+    allocate(self%tod(self%ntod, self%ndet))
+    allocate(self%n_corr(self%ntod, self%ndet))
+    allocate(self%s_sl(self%ntod, self%ndet, self%nhorn))
+    allocate(self%s_sky(self%ntod, self%ndet, self%nhorn))
+    allocate(self%s_bp(self%ntod, self%ndet, self%nhorn))
+    allocate(self%s_orb(self%ntod, self%ndet, self%nhorn))
+    allocate(self%s_tot(self%ntod, self%ndet, self%nhorn))
+    allocate(self%s_buf(self%ntod, self%ndet))
+    allocate(self%mask(self%ntod, self%ndet))
+    allocate(self%pix(self%ntod, self%ndet, self%nhorn))
+    allocate(self%psi(self%ntod, self%ndet, self%nhorn))
+    allocate(self%flag(self%ntod, self%ndet))
+    if (init_s_sky_prop_)   allocate(self%s_sky_prop(self%ntod, self%ndet, self%nhorn, 2:self%ndelta))
+    if (init_s_bp_prop_)    allocate(self%s_bp_prop(self%ntod, self%ndet, self%nhorn, 2:self%ndelta))
+    if (init_s_sky_prop_)   allocate(self%mask2(self%ntod, self%ndet))
+    if (tod%sample_mono)    allocate(self%s_mono(self%ntod, self%ndet))
+    if (tod%subtract_zodi)  allocate(self%s_zodi(self%ntod, self%ndet, self%nhorn))
+
+    ! Decompress pointing, psi and flags for current scan
+    do j = 1, self%ndet
+       if (.not. tod%scans(scan)%d(j)%accept) cycle
+       call tod%decompress_pointing_and_flags(scan, j, self%pix(:,j,:), &
+            & self%psi(:,j,:), self%flag(:,j))
+    end do
+    call tod%symmetrize_flags(self%flag)
+    
+    ! Prepare TOD
+    do j = 1, self%ndet
+       if (.not. tod%scans(scan)%d(j)%accept) cycle
+       if (tod%compressed_tod) then
+          !call tod%decompress_tod(scan, j, self%tod(:,j))
+       else
+          self%tod(:,j) = tod%scans(scan)%d(j)%tod
+       end if
+    end do
+
+    ! Construct sky signal template
+    do k = 1, self%nhorn
+       if (init_s_bp_) then
+          call project_sky(tod, map_sky(:,:,:,1), self%pix(:,:,k:k), self%psi(:,:,k:k), self%flag, &
+               & sprocmask%a, scan, self%s_sky(:,:,k), self%mask, s_bp=self%s_bp(:,:,k))
+       else
+          call project_sky(tod, map_sky(:,:,:,1), self%pix(:,:,k:k), self%psi(:,:,k:k), self%flag, &
+               & sprocmask%a, scan, self%s_sky(:,:,k), self%mask)
+       end if
+    end do
+
+    ! Set up (optional) bandpass sampling quantities (s_sky_prop, mask2 and bp_prop)
+    do k = 1, self%nhorn
+       if (init_s_bp_prop_) then
+          do j = 2, size(map_sky,4)
+             call project_sky(tod, map_sky(:,:,:,j), self%pix(:,:,k:k), self%psi(:,:,k:k), self%flag, &
+                  & sprocmask2%a, scan, self%s_sky_prop(:,:,k,j), self%mask2, s_bp=self%s_bp_prop(:,:,k,j))
+          end do
+       else if (init_s_sky_prop_) then
+          do j = 2, size(map_sky,4)
+             call project_sky(tod, map_sky(:,:,:,j), self%pix(:,:,k:k), self%psi(:,:,k:k), self%flag, &
+                  & sprocmask2%a, scan, self%s_sky_prop(:,:,k,j), self%mask2)
+          end do
+       end if
+    end do
+
+    ! Perform sanity tests
+    do j = 1, self%ndet
+       if (.not. tod%scans(scan)%d(j)%accept) cycle
+       if (all(self%mask(:,j) == 0)) tod%scans(scan)%d(j)%accept = .false.
+       if (tod%scans(scan)%d(j)%sigma0 <= 0.d0) tod%scans(scan)%d(j)%accept = .false.
+    end do
+    
+    ! Construct orbital dipole template
+    do k = 1, tod%nhorn
+       if (tod%orb_4pi_beam) then
+          !call tod%orb_dp%p%compute_orbital_dipole_4pi(scan, self%pix(:,:,k), self%psi(:,:,k), self%s_orb(:,:,k))
+       else
+          ! Duncan: Fix units on your side to get rid of the 1d3 scaling factor
+          !call tod%orb_dp%p%compute_orbital_dipole_pencil(scan, self%pix(:,:,k), self%psi(:,:,k), self%s_orb(:,:,k))
+       end if
+    end do
+
+    ! Construct zodical light template
+    if (tod%subtract_zodi) then
+       do k = 1, self%nhorn
+          call compute_zodi_template(tod%nside, self%pix(:,:,k), tod%scans(scan)%satpos, tod%nu_c, self%s_zodi(:,:,k))
+       end do
+    end if
+
+    ! Construct sidelobe template
+    if (tod%correct_sl) then
+       do j = 1, self%ndet
+          if (.not. tod%scans(scan)%d(j)%accept) cycle
+          do k = 1, self%nhorn
+             call tod%construct_sl_template(tod%slconv(j)%p, &
+                  & self%pix(:,j,1), self%psi(:,j,1), self%s_sl(:,j,k), tod%polang(j))
+             self%s_sl(:,j,k) = 2.d0 * self%s_sl(:,j,k) ! Scaling by a factor of 2, by comparison with LevelS. Should be understood
+          end do
+       end do
+    else
+       do j = 1, self%ndet
+          if (.not. tod%scans(scan)%d(j)%accept) cycle
+          self%s_sl(:,j,:) = 0.
+       end do
+    end if
+
+    ! Construct monopole correction template
+    if (tod%sample_mono) then
+       do j = 1, self%ndet
+          if (.not. tod%scans(scan)%d(j)%accept) cycle
+          !self%s_mono(:,j) = tod%mono(j)
+          self%s_mono(:,j) = 0.d0 ! Disabled for now
+       end do
+    end if
+
+    ! Construct total sky signal
+    do j = 1, self%ndet
+       if (.not. tod%scans(scan)%d(j)%accept) cycle
+       self%s_tot(:,j,:) = self%s_sky(:,j,:) + self%s_sl(:,j,:) + self%s_orb(:,j,:)
+       do k = 1, self%nhorn
+          if (tod%sample_mono) self%s_tot(:,j,k) = self%s_tot(:,j,k) + self%s_mono(:,j)
+       end do
+    end do
+
+  end subroutine init_scan_data
+
+  subroutine dealloc_scan_data(self)
+    implicit none
+    class(scan_data), intent(inout) :: self    
+
+    self%ntod = -1; self%ndet = -1; self%nhorn = -1
+
+    ! Deallocate data structures
+    deallocate(self%tod, self%n_corr, self%s_sl, self%s_sky)
+    deallocate(self%s_orb, self%s_tot, self%s_buf, self%mask)
+    deallocate(self%pix, self%psi, self%flag)
+    if (allocated(self%s_sky_prop))  deallocate(self%s_sky_prop)
+    if (allocated(self%s_bp_prop))   deallocate(self%s_bp_prop)
+    if (allocated(self%s_bp))        deallocate(self%s_bp)
+    if (allocated(self%s_mono))      deallocate(self%s_mono)
+    if (allocated(self%mask2))       deallocate(self%mask2)
+    if (allocated(self%s_zodi))      deallocate(self%s_zodi)
+
+  end subroutine dealloc_scan_data
+
+
+end module comm_tod_driver_mod

--- a/commander3/src/comm_tod_gain_mod.f90
+++ b/commander3/src/comm_tod_gain_mod.f90
@@ -28,12 +28,10 @@ module comm_tod_gain_mod
 
 contains
 
-
   ! Compute gain as g = (d-n_corr-n_temp)/(map + dipole_orb), where map contains an 
   ! estimate of the stationary sky
-  ! Haavard: Get rid of explicit n_corr, and replace 1/sigma**2 with proper invN multiplication
-!  subroutine sample_gain_per_scan(self, handle, det, scan_id, n_corr, mask, s_ref)
-!   subroutine calculate_gain_mean_std_per_scan(self, det, scan_id, s_tot, invn, mask)
+  !  subroutine sample_gain_per_scan(self, handle, det, scan_id, n_corr, mask, s_ref)
+  !  subroutine calculate_gain_mean_std_per_scan(self, det, scan_id, s_tot, invn, mask)
    subroutine calculate_gain_mean_std_per_scan(tod, scan_id, s_invN, mask, s_ref, s_tot, handle, mask_lowres, tod_arr)
     implicit none
     class(comm_tod),                      intent(inout) :: tod

--- a/commander3/src/comm_tod_gain_mod.f90
+++ b/commander3/src/comm_tod_gain_mod.f90
@@ -487,6 +487,7 @@ contains
          r_fill = tod_arr(:,j)-s_sub(:,j) - tod%scans(scan)%d(j)%baseline
        else
          r_fill = tod%scans(scan)%d(j)%tod - s_sub(:,j) - tod%scans(scan)%d(j)%baseline
+         !if (tod%scanid(scan) == 1348 .and. out) write(*,*) tod%scanid(scan), sum(abs(tod%scans(scan)%d(j)%tod)), sum(abs(s_sub(:,j))), tod%scans(scan)%d(j)%baseline
        end if
        call fill_all_masked(r_fill, mask(:,j), ntod, trim(tod%operation) == 'sample', abs(real(tod%scans(scan)%d(j)%sigma0, sp)), handle, tod%scans(scan)%chunk_num)
        call tod%downsample_tod(r_fill, ext, residual(:,j))
@@ -503,7 +504,7 @@ contains
           A_abs(j) = A_abs(j) + sum(s_invN(:,j) * s_ref(:,j))
           b_abs(j) = b_abs(j) + sum(s_invN(:,j) * residual(:,j))
        end if
-       !if (out) write(*,*) tod%scanid(scan), real(sum(s_invN(:,j) * residual(:,j))/sum(s_invN(:,j) * s_ref(:,j)),sp), real(1/sqrt(sum(s_invN(:,j) * s_ref(:,j))),sp), '  # absK', j
+       !if (tod%scanid(scan) == 1348 .and. out) write(*,*) tod%scanid(scan), real(sum(s_invN(:,j) * residual(:,j))/sum(s_invN(:,j) * s_ref(:,j)),sp), real(1/sqrt(sum(s_invN(:,j) * s_ref(:,j))),sp), '  # absK', j, sum(abs(s_invN(:,j))), sum(abs(s_ref(:,j))), sum(abs( mask_lowres(:,j))), sum(abs(residual(:,j))), sum(s_invN(:,j) * s_ref(:,j)    * mask_lowres(:,j)), sum(s_invN(:,j) * residual(:,j) * mask_lowres(:,j))
     end do
 
 !    if (trim(tod%freq) == '070') then
@@ -511,8 +512,8 @@ contains
  !   end if
 
 
-    !if (.false. .and. mod(tod%scanid(scan),1000) == 0 .and. out) then
-    if (out) then
+    if (.false. .and. out) then
+    !if (sum(s_invN(:,4) * residual(:,4) * mask_lowres(:,4))/sum(s_invN(:,4) * s_ref(:,4) * mask_lowres(:,4)) < -0.5d0) then
        call int2string(tod%scanid(scan), itext)
        !write(*,*) 'gain'//itext//'   = ', tod%gain0(0) + tod%gain0(1), tod%gain0(0), tod%gain0(1)
        open(58,file='gainfit3_'//itext//'.dat')
@@ -527,12 +528,12 @@ contains
        scale = sum(s_invN(:,1) * residual(:,1)) / sum(s_invN(:,1) * s_ref(:,1))
        residual(:,1) = residual(:,1) - scale * s_ref(:,1)
        do i = 1, size(s_ref,1)
-          write(58,*) i-ext(1)+1, residual(i,1) 
+          write(58,*) i+ext(1)-1, residual(i+ext(1)-1,1) 
        end do
        if (present(mask_lowres)) then
           write(58,*)
           do i = 1, size(s_ref,1)
-             write(58,*) i-ext(1)+1, mask_lowres(i,1) 
+             write(58,*) i+ext(1)-1, mask_lowres(i,1) 
           end do
        end if
        close(58)
@@ -651,9 +652,9 @@ contains
        coeff_matrix(tod%ndet+1, tod%ndet+1) = 0.d0
        rhs(tod%ndet+1) = 0.d0
        call solve_system_real(coeff_matrix, x, rhs)
-       !if (tod%verbosity > 1) then
-       !  write(*,*) 'relcal = ', real(x,sp)
-       !end if
+       if (tod%verbosity > 1) then
+         write(*,*) 'relcal = ', real(x,sp)
+       end if
     end if
     call mpi_bcast(x, tod%ndet+1, MPI_DOUBLE_PRECISION, 0, &
        & tod%info%comm, ierr)

--- a/commander3/src/comm_tod_gain_mod.f90
+++ b/commander3/src/comm_tod_gain_mod.f90
@@ -512,7 +512,7 @@ contains
 
 
     !if (.false. .and. mod(tod%scanid(scan),1000) == 0 .and. out) then
-    if (.false. .and. out) then
+    if (out) then
        call int2string(tod%scanid(scan), itext)
        !write(*,*) 'gain'//itext//'   = ', tod%gain0(0) + tod%gain0(1), tod%gain0(0), tod%gain0(1)
        open(58,file='gainfit3_'//itext//'.dat')

--- a/commander3/src/comm_tod_mapmaking_mod.f90
+++ b/commander3/src/comm_tod_mapmaking_mod.f90
@@ -25,66 +25,169 @@ module comm_tod_mapmaking_mod
    use comm_map_mod
    implicit none
 
+   type comm_binmap
+      integer(i4b)       :: ncol, n_A, nout, nobs, npix, numprocs_shared, chunk_size
+      logical(lgt)       :: shared, solve_S
+      type(shared_2d_dp) :: sA_map
+      type(shared_3d_dp) :: sb_map
+      class(map_ptr), allocatable, dimension(:)     :: outmaps
+      real(dp),       allocatable, dimension(:,:)   :: A_map
+      real(dp),       allocatable, dimension(:,:,:) :: b_map
+    contains
+      procedure :: init    => init_binmap
+      procedure :: dealloc => dealloc_binmap
+      procedure :: synchronize => syncronize_binmap
+   end type comm_binmap
+
 contains
 
+  subroutine init_binmap(self, tod, shared, solve_S)
+    implicit none
+    class(comm_binmap),  intent(inout) :: self
+    class(comm_tod),     intent(in)    :: tod
+    logical(lgt),        intent(in)    :: shared, solve_S
+
+    integer(i4b) :: i, ierr
+
+    self%nobs            = tod%nobs
+    self%shared          = shared
+    self%solve_S         = solve_S
+    self%npix            = tod%info%npix
+    self%numprocs_shared = tod%numprocs_shared
+    self%chunk_size      = self%npix/self%numprocs_shared
+    if (solve_S) then
+       self%ncol = tod%nmaps + tod%ndet - 1
+       self%n_A  = tod%nmaps*(tod%nmaps+1)/2 + 4*(tod%ndet-1)
+       self%nout = tod%output_n_maps + size(tod%bp_delta,2) - 1
+    else
+       self%ncol = tod%nmaps
+       self%n_A  = tod%nmaps*(tod%nmaps+1)/2
+       self%nout = tod%output_n_maps
+    end if
+    allocate(self%outmaps(self%nout))
+    do i = 1, self%nout
+       self%outmaps(i)%p => comm_map(tod%info)
+    end do
+    allocate(self%A_map(self%n_A,self%nobs), self%b_map(self%nout,self%ncol,self%nobs))
+    self%A_map = 0.d0; self%b_map = 0.d0
+    if (self%shared) then
+       call init_shared_2d_dp(tod%myid_shared, tod%comm_shared, &
+            & tod%myid_inter, tod%comm_inter, [self%n_A,self%npix], self%sA_map)
+       call mpi_win_fence(0, self%sA_map%win, ierr)
+       if (self%sA_map%myid_shared == 0) self%sA_map%a = 0.d0
+       call mpi_win_fence(0, self%sA_map%win, ierr)
+       call init_shared_3d_dp(tod%myid_shared, tod%comm_shared, &
+               & tod%myid_inter, tod%comm_inter, [self%nout,self%ncol,self%npix], self%sb_map)
+       call mpi_win_fence(0, self%sb_map%win, ierr)
+       if (self%sb_map%myid_shared == 0) self%sb_map%a = 0.d0
+       call mpi_win_fence(0, self%sb_map%win, ierr)
+    else
+
+    end if
+
+  end subroutine init_binmap
+
+
+  subroutine dealloc_binmap(self)
+    implicit none
+    class(comm_binmap), intent(inout) :: self
+
+    integer(i4b) ::  i
+
+    if (allocated(self%A_map)) deallocate(self%A_map, self%b_map)
+    if (self%sA_map%init)  call dealloc_shared_2d_dp(self%sA_map)
+    if (self%sb_map%init)  call dealloc_shared_3d_dp(self%sb_map)
+    if (allocated(self%outmaps)) then
+       do i = 1, self%nout
+          call self%outmaps(i)%p%dealloc
+       end do
+       deallocate(self%outmaps)
+    end if
+
+  end subroutine dealloc_binmap
+
+  subroutine syncronize_binmap(self, tod)
+    implicit none
+    class(comm_binmap),  intent(inout) :: self
+    class(comm_tod),     intent(in)    :: tod
+
+    integer(i4b) :: i, j, start_chunk, end_chunk, ierr
+
+    if (.not. self%shared) return
+
+    do i = 0, self%numprocs_shared-1
+       start_chunk = mod(self%sA_map%myid_shared+i,self%numprocs_shared)*self%chunk_size
+       end_chunk   = min(start_chunk+self%chunk_size-1,self%npix-1)
+       do while (start_chunk < self%npix)
+          if (tod%pix2ind(start_chunk) /= -1) exit
+          start_chunk = start_chunk+1
+       end do
+       do while (end_chunk >= start_chunk)
+          if (tod%pix2ind(end_chunk) /= -1) exit
+          end_chunk = end_chunk-1
+       end do
+       if (start_chunk < self%npix)  start_chunk = tod%pix2ind(start_chunk)
+       if (end_chunk >= start_chunk) end_chunk   = tod%pix2ind(end_chunk)
+
+       call mpi_win_fence(0, self%sA_map%win, ierr)
+       call mpi_win_fence(0, self%sb_map%win, ierr)
+       do j = start_chunk, end_chunk
+          self%sA_map%a(:,tod%ind2pix(j)+1) = self%sA_map%a(:,tod%ind2pix(j)+1) + &
+                  & self%A_map(:,j)
+          self%sb_map%a(:,:,tod%ind2pix(j)+1) = self%sb_map%a(:,:,tod%ind2pix(j)+1) + &
+                  & self%b_map(:,:,j)
+       end do
+    end do
+    call mpi_win_fence(0, self%sA_map%win, ierr)
+    call mpi_win_fence(0, self%sb_map%win, ierr)
+
+  end subroutine syncronize_binmap
 
   ! Compute map with white noise assumption from correlated noise 
   ! corrected and calibrated data, d' = (d-n_corr-n_temp)/gain 
-  subroutine bin_TOD(tod, data, pix, psi, flag, A, b, scan, comp_S, b_mono)
+  subroutine bin_TOD(tod, scan, pix, psi, flag, data, binmap)
     implicit none
     class(comm_tod),                             intent(in)    :: tod
     integer(i4b),                                intent(in)    :: scan
-    real(sp),            dimension(1:,1:,1:),    intent(in)    :: data
     integer(i4b),        dimension(1:,1:),       intent(in)    :: pix, psi, flag
-    real(dp),            dimension(1:,1:),       intent(inout) :: A
-    real(dp),            dimension(1:,1:,1:),    intent(inout) :: b
-    real(dp),            dimension(1:,1:,1:),    intent(inout), optional :: b_mono
-    logical(lgt),                                intent(in)    :: comp_S
+    real(sp),            dimension(1:,1:,1:),    intent(in)    :: data
+    type(comm_binmap),                           intent(inout) :: binmap
 
     integer(i4b) :: det, i, t, pix_, off, nout, psi_
     real(dp)     :: inv_sigmasq
 
-    nout        = size(b,dim=1)
-
-    do det = 1, tod%ndet
+    nout = binmap%nout
+    do det = 1, size(pix,2)
        if (.not. tod%scans(scan)%d(det)%accept) cycle
-       !write(*,*) tod%scanid(scan), det, tod%scans(scan)%d(det)%sigma0
        off         = 6 + 4*(det-1)
        inv_sigmasq = (tod%scans(scan)%d(det)%gain/tod%scans(scan)%d(det)%sigma0)**2
-       do t = 1, tod%scans(scan)%ntod
+       do t = 1, size(pix,1)
           
           if (iand(flag(t,det),tod%flag0) .ne. 0) cycle
-         !if (flag(t,det)==1) cycle
           
           pix_    = tod%pix2ind(pix(t,det))
           psi_    = psi(t,det)
           
-          A(1,pix_) = A(1,pix_) + 1.d0                                  * inv_sigmasq
-          A(2,pix_) = A(2,pix_) + tod%cos2psi(psi_)                    * inv_sigmasq
-          A(3,pix_) = A(3,pix_) + tod%cos2psi(psi_)**2                 * inv_sigmasq
-          A(4,pix_) = A(4,pix_) + tod%sin2psi(psi_)                    * inv_sigmasq
-          A(5,pix_) = A(5,pix_) + tod%cos2psi(psi_)*tod%sin2psi(psi_) * inv_sigmasq
-          A(6,pix_) = A(6,pix_) + tod%sin2psi(psi_)**2                 * inv_sigmasq
+          binmap%A_map(1,pix_) = binmap%A_map(1,pix_) + 1.d0                                 * inv_sigmasq
+          binmap%A_map(2,pix_) = binmap%A_map(2,pix_) + tod%cos2psi(psi_)                    * inv_sigmasq
+          binmap%A_map(3,pix_) = binmap%A_map(3,pix_) + tod%cos2psi(psi_)**2                 * inv_sigmasq
+          binmap%A_map(4,pix_) = binmap%A_map(4,pix_) + tod%sin2psi(psi_)                    * inv_sigmasq
+          binmap%A_map(5,pix_) = binmap%A_map(5,pix_) + tod%cos2psi(psi_)*tod%sin2psi(psi_) * inv_sigmasq
+          binmap%A_map(6,pix_) = binmap%A_map(6,pix_) + tod%sin2psi(psi_)**2                 * inv_sigmasq
           
           do i = 1, nout
-             b(i,1,pix_) = b(i,1,pix_) + data(i,t,det)                      * inv_sigmasq
-             b(i,2,pix_) = b(i,2,pix_) + data(i,t,det) * tod%cos2psi(psi_) * inv_sigmasq
-             b(i,3,pix_) = b(i,3,pix_) + data(i,t,det) * tod%sin2psi(psi_) * inv_sigmasq
+             binmap%b_map(i,1,pix_) = binmap%b_map(i,1,pix_) + data(i,t,det)                      * inv_sigmasq
+             binmap%b_map(i,2,pix_) = binmap%b_map(i,2,pix_) + data(i,t,det) * tod%cos2psi(psi_) * inv_sigmasq
+             binmap%b_map(i,3,pix_) = binmap%b_map(i,3,pix_) + data(i,t,det) * tod%sin2psi(psi_) * inv_sigmasq
           end do
           
-          if (present(b_mono)) then
-             b_mono(1,pix_,det) = b_mono(1,pix_,det) +                      inv_sigmasq
-             b_mono(2,pix_,det) = b_mono(2,pix_,det) + tod%cos2psi(psi_) * inv_sigmasq
-             b_mono(3,pix_,det) = b_mono(3,pix_,det) + tod%sin2psi(psi_) * inv_sigmasq
-          end if
-          
-          if (comp_S .and. det < tod%ndet) then
-             A(off+1,pix_) = A(off+1,pix_) + 1.d0               * inv_sigmasq 
-             A(off+2,pix_) = A(off+2,pix_) + tod%cos2psi(psi_) * inv_sigmasq
-             A(off+3,pix_) = A(off+3,pix_) + tod%sin2psi(psi_) * inv_sigmasq
-             A(off+4,pix_) = A(off+4,pix_) + 1.d0               * inv_sigmasq
+          if (binmap%solve_S .and. det < tod%ndet) then
+             binmap%A_map(off+1,pix_) = binmap%A_map(off+1,pix_) + 1.d0               * inv_sigmasq 
+             binmap%A_map(off+2,pix_) = binmap%A_map(off+2,pix_) + tod%cos2psi(psi_) * inv_sigmasq
+             binmap%A_map(off+3,pix_) = binmap%A_map(off+3,pix_) + tod%sin2psi(psi_) * inv_sigmasq
+             binmap%A_map(off+4,pix_) = binmap%A_map(off+4,pix_) + 1.d0               * inv_sigmasq
              do i = 1, nout
-                b(i,det+3,pix_) = b(i,det+3,pix_) + data(i,t,det) * inv_sigmasq 
+                binmap%b_map(i,det+3,pix_) = binmap%b_map(i,det+3,pix_) + data(i,t,det) * inv_sigmasq 
              end do
           end if
           
@@ -276,20 +379,15 @@ end subroutine bin_differential_TOD
 
    end subroutine compute_Ax
 
-  subroutine finalize_binned_map(tod, handle, sA_map, sb_map, rms, outmaps, chisq_S, Sfile, mask, sb_mono, sys_mono, condmap)
+  subroutine finalize_binned_map(tod, binmap, handle, rms, scale, chisq_S, mask)
     implicit none
     class(comm_tod),                      intent(in)    :: tod
+    type(comm_binmap),                    intent(inout) :: binmap
     type(planck_rng),                     intent(inout) :: handle
-    type(shared_2d_dp), intent(inout) :: sA_map
-    type(shared_3d_dp), intent(inout) :: sb_map
     class(comm_map),                      intent(inout) :: rms
-    class(map_ptr),  dimension(1:),       intent(inout), optional :: outmaps
+    real(dp),                             intent(in)    :: scale
     real(dp),        dimension(1:,1:),    intent(out),   optional :: chisq_S
-    character(len=*),                     intent(in),    optional :: Sfile
-    integer(i4b),    dimension(0:),       intent(in),    optional :: mask
-    type(shared_3d_dp), intent(inout), optional :: sb_mono
-    real(dp),        dimension(1:,1:,0:), intent(out),   optional :: sys_mono
-    class(comm_map),                      intent(inout), optional :: condmap
+    real(sp),        dimension(0:),       intent(in),    optional :: mask
 
     integer(i4b) :: i, j, k, nmaps, ierr, ndet, ncol, n_A, off, ndelta
     integer(i4b) :: det, nout, np0, comm, myid, nprocs
@@ -304,83 +402,46 @@ end subroutine bin_differential_TOD
     nprocs= tod%numprocs
     comm  = tod%comm
     np0   = tod%info%np
-    nout  = size(sb_map%a,dim=1)
+    nout  = size(binmap%sb_map%a,dim=1)
     nmaps = tod%info%nmaps
     ndet  = tod%ndet
-    n_A   = size(sA_map%a,dim=1)
-    ncol  = size(sb_map%a,dim=2)
+    n_A   = size(binmap%sA_map%a,dim=1)
+    ncol  = size(binmap%sb_map%a,dim=2)
     ndelta = 0; if (present(chisq_S)) ndelta = size(chisq_S,dim=2)
 
     ! Collect contributions from all nodes
-    !call update_status(status, "tod_final1")
-    call mpi_win_fence(0, sA_map%win, ierr)
-    if (sA_map%myid_shared == 0) then
-       !allocate(buff_2d(size(sA_map%a,1),size(sA_map%a,2)))
-       
-
-!       call mpi_allreduce(sA_map%a, buff_2d, size(sA_map%a), &
-!            & MPI_DOUBLE_PRECISION, MPI_SUM, sA_map%comm_inter, ierr)
-         do i = 1, size(sA_map%a, 1)
-            call mpi_allreduce(MPI_IN_PLACE, sA_map%a(i, :), size(sA_map%a, 2), &
-                 & MPI_DOUBLE_PRECISION, MPI_SUM, sA_map%comm_inter, ierr)
+    call mpi_win_fence(0, binmap%sA_map%win, ierr)
+    if (binmap%sA_map%myid_shared == 0) then
+       do i = 1, size(binmap%sA_map%a, 1)
+          call mpi_allreduce(MPI_IN_PLACE, binmap%sA_map%a(i, :), size(binmap%sA_map%a, 2), &
+               & MPI_DOUBLE_PRECISION, MPI_SUM, binmap%sA_map%comm_inter, ierr)
+       end do
+    end if
+      call mpi_win_fence(0, binmap%sA_map%win, ierr)
+      call mpi_win_fence(0, binmap%sb_map%win, ierr)
+      if (binmap%sb_map%myid_shared == 0) then
+         do i = 1, size(binmap%sb_map%a, 1)
+            call mpi_allreduce(mpi_in_place, binmap%sb_map%a(i, :, :), size(binmap%sb_map%a(1, :, :)), &
+                 & MPI_DOUBLE_PRECISION, MPI_SUM, binmap%sb_map%comm_inter, ierr)
          end do
-         !sA_map%a = buff_2d
-         !deallocate(buff_2d)
       end if
-      call mpi_win_fence(0, sA_map%win, ierr)
-      call mpi_win_fence(0, sb_map%win, ierr)
-      if (sb_map%myid_shared == 0) then
-         !allocate(buff_3d(size(sb_map%a,1),size(sb_map%a,2),size(sb_map%a,3)))
-         !call mpi_allreduce(sb_map%a, buff_3d, size(sb_map%a), &
-         !     & MPI_DOUBLE_PRECISION, MPI_SUM, sb_map%comm_inter, ierr)
-         do i = 1, size(sb_map%a, 1)
-            call mpi_allreduce(mpi_in_place, sb_map%a(i, :, :), size(sb_map%a(1, :, :)), &
-                 & MPI_DOUBLE_PRECISION, MPI_SUM, sb_map%comm_inter, ierr)
-         end do
-         !sb_map%a = buff_3d
-         !deallocate(buff_3d)
-      end if
-      call mpi_win_fence(0, sb_map%win, ierr)
-      if (present(sb_mono)) then
-         call mpi_win_fence(0, sb_mono%win, ierr)
-         if (sb_mono%myid_shared == 0) then
-            call mpi_allreduce(MPI_IN_PLACE, sb_mono%a, size(sb_mono%a), &
-                 & MPI_DOUBLE_PRECISION, MPI_SUM, sb_mono%comm_inter, ierr)
-         end if
-         call mpi_win_fence(0, sb_mono%win, ierr)
-      end if
+      call mpi_win_fence(0, binmap%sb_map%win, ierr)
 
       allocate (A_tot(n_A, 0:np0 - 1), b_tot(nout, nmaps, 0:np0 - 1), bs_tot(nout, ncol, 0:np0 - 1), W(nmaps), eta(nmaps))
-      A_tot = sA_map%a(:, tod%info%pix + 1)
-      b_tot = sb_map%a(:, 1:nmaps, tod%info%pix + 1)
-      bs_tot = sb_map%a(:, :, tod%info%pix + 1)
-      if (present(sb_mono)) then
-         do j = 1, ndet
-            sys_mono(:, nmaps + j, :) = sb_mono%a(:, tod%info%pix + 1, j)
-         end do
-      end if
-      !call update_status(status, "tod_final2")
+      A_tot = binmap%sA_map%a(:, tod%info%pix + 1)
+      b_tot = binmap%sb_map%a(:, 1:nmaps, tod%info%pix + 1)
+      bs_tot = binmap%sb_map%a(:, :, tod%info%pix + 1)
 
       ! Solve for local map and rms
-      if (present(Sfile)) then
-         info => comm_mapinfo(tod%comm, tod%info%nside, 0, ndet - 1, .false.)
-         smap => comm_map(info)
-         smap%map = 0.d0
-      end if
       allocate (A_inv(nmaps, nmaps), As_inv(ncol, ncol))
-      !if (present(chisq_S)) smap%map = 0.d0
       if (present(chisq_S)) chisq_S = 0.d0
       do i = 0, np0 - 1
          if (all(b_tot(1, :, i) == 0.d0)) then
-            !write(*,*) 'missing pixel',i, tod%myid
-            if (present(sb_mono)) sys_mono(1:nmaps, 1:nmaps, i) = 0.d0
             if (.not. present(chisq_S)) then
                rms%map(i, :) = 0.d0
-               if (present(outmaps)) then
-                  do k = 1, nout
-                     outmaps(k)%p%map(i, :) = 0.d0
-                  end do
-               end if
+               do k = 1, nout
+                  binmap%outmaps(k)%p%map(i, :) = 0.d0
+               end do
             end if
             cycle
          end if
@@ -410,28 +471,10 @@ end subroutine bin_differential_TOD
             end do
          end if
 
-         if (present(condmap)) then
-            call get_eigenvalues(A_inv(1:nmaps, 1:nmaps), W)
-            if (minval(W) < 0.d0) then
-!             if (maxval(W) == 0.d0 .or. minval(W) == 0.d0) then
-               write (*, *) 'A_inv: ', A_inv
-               write (*, *) 'W', W
-!             end if
-            end if
-            if (minval(W) > 0) then
-               condmap%map(i, 1) = log10(max(abs(maxval(W)/minval(W)), 1.d0))
-            else
-               condmap%map(i, 1) = 30.d0
-            end if
-         end if
-
          call invert_singular_matrix(A_inv, 1d-12)
          do k = 1, tod%output_n_maps
             b_tot(k, 1:nmaps, i) = matmul(A_inv, b_tot(k, 1:nmaps, i))
          end do
-!!$       if (tod%info%pix(i) == 100) then
-!!$          write(*,*) 'b', b_tot(:,:,i)
-!!$       end if
          if (present(chisq_S)) then
             call invert_singular_matrix(As_inv, 1d-12)
             bs_tot(1, 1:ncol, i) = matmul(As_inv, bs_tot(1, 1:ncol, i))
@@ -440,27 +483,21 @@ end subroutine bin_differential_TOD
             end do
          end if
 
-         if (present(sb_mono)) sys_mono(1:nmaps, 1:nmaps, i) = A_inv(1:nmaps, 1:nmaps)
          if (present(chisq_S)) then
             do j = 1, ndet - 1
-               if (mask(tod%info%pix(i + 1)) == 0) cycle
+               if (mask(tod%info%pix(i + 1)) == 0.) cycle
                if (As_inv(nmaps + j, nmaps + j) <= 0.d0) cycle
                chisq_S(j, 1) = chisq_S(j, 1) + bs_tot(1, nmaps + j, i)**2/As_inv(nmaps + j, nmaps + j)
                do k = 2, ndelta
                   chisq_S(j, k) = chisq_S(j, k) + bs_tot(tod%output_n_maps + k - 1, nmaps + j, i)**2/As_inv(nmaps + j, nmaps + j)
                end do
-               if (present(Sfile) .and. As_inv(nmaps + j, nmaps + j) > 0.d0) then
-                  smap%map(i, j) = bs_tot(1, nmaps + j, i)/sqrt(As_inv(nmaps + j, nmaps + j))
-               end if
             end do
          end if
          do j = 1, nmaps
-            rms%map(i, j) = sqrt(A_inv(j, j))*1.d6 ! uK
-            if (present(outmaps)) then
-               do k = 1, tod%output_n_maps
-                  outmaps(k)%p%map(i, j) = b_tot(k, j, i)*1.d6 ! uK
-               end do
-            end if
+            rms%map(i, j) = sqrt(A_inv(j, j))*scale
+            do k = 1, tod%output_n_maps
+               binmap%outmaps(k)%p%map(i, j) = b_tot(k, j, i)*scale
+            end do
          end do
       end do
 
@@ -472,149 +509,11 @@ end subroutine bin_differential_TOD
             call mpi_reduce(chisq_S, chisq_S, size(chisq_S), &
                  & MPI_DOUBLE_PRECISION, MPI_SUM, 0, comm, ierr)
          end if
-         if (present(Sfile)) call smap%writeFITS(trim(Sfile))
       end if
-
-      if (present(Sfile)) call smap%dealloc
 
       deallocate (A_inv, As_inv, A_tot, b_tot, bs_tot, W, eta)
 
    end subroutine finalize_binned_map
 
-   subroutine sample_mono(tod, handle, sys_mono, res, rms, mask)
-      implicit none
-      class(comm_tod), intent(inout) :: tod
-      type(planck_rng), intent(inout) :: handle
-      real(dp), dimension(1:, 1:, 0:), intent(in)    :: sys_mono
-      class(comm_map), intent(in)    :: res, rms, mask
-
-      integer(i4b) :: i, j, k, nstep, nmaps, ndet, ierr
-      real(dp)     :: t1, t2, s(3), b(3), alpha, sigma, chisq, chisq0, chisq_prop, naccept
-      logical(lgt) :: accept, first_call
-      real(dp), allocatable, dimension(:)   :: mono0, mono_prop, mu, eta
-      real(dp), allocatable, dimension(:, :) :: samples
-
-      call wall_time(t1)
-
-      first_call = .not. allocated(tod%L_prop_mono)
-      sigma = 0.03d-6 ! RMS proposal in K
-      alpha = 1.2d0   ! Covariance matrix scaling factor
-      nmaps = size(sys_mono, dim=1)
-      ndet = size(sys_mono, dim=2) - nmaps
-      allocate (mono0(ndet), mono_prop(ndet), eta(ndet), mu(ndet))
-
-      ! Initialize monopoles on existing values
-      if (tod%myid == 0) then
-         do j = 1, ndet
-            mono0(j) = tod%mono(j)
-         end do
-
-         if (first_call) then
-            allocate (tod%L_prop_mono(ndet, ndet))
-            tod%L_prop_mono = 0.d0
-            do i = 1, ndet
-               tod%L_prop_mono(i, i) = sigma
-            end do
-            nstep = 100000
-            allocate (samples(ndet, nstep))
-         else
-            nstep = 1000
-         end if
-      end if
-      call mpi_bcast(mono0, ndet, MPI_DOUBLE_PRECISION, 0, res%info%comm, ierr)
-      call mpi_bcast(nstep, 1, MPI_INTEGER, 0, res%info%comm, ierr)
-
-      ! Compute chisquare for old values; only include Q and U in evaluation;
-      ! add old correction to output map
-      chisq = 0.d0
-      do k = 0, res%info%np - 1
-         b = 0.d0
-         do j = 1, ndet
-            b = b + mono0(j)*sys_mono(:, nmaps + j, k)
-         end do
-         s = matmul(sys_mono(1:3, 1:3, k), b)*1.d6 ! uK
-         if (mask%map(k, 1) == 1.d0) then
-            chisq = chisq + sum((res%map(k, 2:3) - s(2:3))**2/rms%map(k, 2:3)**2)
-         end if
-      end do
-      call mpi_reduce(chisq, chisq0, 1, MPI_DOUBLE_PRECISION, MPI_SUM, 0, res%info%comm, ierr)
-
-      naccept = 0
-      if (res%info%myid == 0) open (78, file='mono.dat', recl=1024)
-      do i = 1, nstep
-
-         ! Propose new monopoles; force zero average
-         if (res%info%myid == 0) then
-            do j = 1, ndet
-               eta(j) = rand_gauss(handle)
-            end do
-            mono_prop = mono0 + matmul(tod%L_prop_mono, eta)
-            mono_prop = mono_prop - mean(mono_prop)
-         end if
-         call mpi_bcast(mono_prop, ndet, MPI_DOUBLE_PRECISION, 0, res%info%comm, ierr)
-
-         ! Compute chisquare for new values; only include Q and U in evaluation
-         chisq = 0.d0
-         do k = 0, res%info%np - 1
-            b = 0.d0
-            do j = 1, ndet
-               b = b + mono_prop(j)*sys_mono(:, nmaps + j, k)
-            end do
-            s = matmul(sys_mono(1:3, 1:3, k), b)*1.d6 ! uK
-            if (mask%map(k, 1) == 1) then
-               chisq = chisq + sum((res%map(k, 2:3) - s(2:3))**2/rms%map(k, 2:3)**2)
-            end if
-         end do
-         call mpi_reduce(chisq, chisq_prop, 1, MPI_DOUBLE_PRECISION, MPI_SUM, 0, res%info%comm, ierr)
-
-         ! Apply Metropolis rule or maximize
-         if (res%info%myid == 0) then
-            if (trim(tod%operation) == 'optimize') then
-               accept = chisq_prop <= chisq0
-            else
-               accept = (rand_uni(handle) < exp(-0.5d0*(chisq_prop - chisq0)))
-            end if
-!!$          write(*,*) 'Mono chisq0 = ', chisq0, ', delta = ', chisq_prop-chisq0
-!!$          write(*,*) 'm0 = ', real(mono0,sp)
-!!$          write(*,*) 'm1 = ', real(mono_prop,sp)
-         end if
-         call mpi_bcast(accept, 1, MPI_LOGICAL, 0, res%info%comm, ierr)
-
-         if (accept) then
-            mono0 = mono_prop
-            chisq0 = chisq_prop
-            naccept = naccept + 1
-         end if
-         if (res%info%myid == 0 .and. mod(i, 100) == 0) write (78, *) i, chisq0, mono0
-         if (first_call) samples(:, i) = mono0
-
-      end do
-      if (res%info%myid == 0) close (78)
-
-      if (first_call .and. res%info%myid == 0) then
-         do i = 1, ndet
-            mu(i) = mean(samples(i, :))
-            do j = 1, i
-               tod%L_prop_mono(i, j) = mean((samples(i, :) - mu(i))*(samples(j, :) - mu(j)))
-            end do
-!          write(*,*) real(tod%L_prop_mono(i,:),sp)
-         end do
-         call compute_hermitian_root(tod%L_prop_mono, 0.5d0)
-         !call cholesky_decompose_single(tod%L_prop_mono)
-         tod%L_prop_mono = alpha*tod%L_prop_mono
-         deallocate (samples)
-      end if
-
-      ! Update parameters
-      tod%mono = mono0
-
-      call wall_time(t2)
-      if (res%info%myid == 0) then
-         write (*, fmt='(a,f8.3,a,f8.3)') 'Time for monopole sampling = ', t2 - t1, ', accept = ', naccept/nstep
-      end if
-
-      deallocate (mono0, mono_prop, eta, mu)
-
-   end subroutine sample_mono
 
 end module comm_tod_mapmaking_mod

--- a/commander3/src/comm_tod_mapmaking_mod.f90
+++ b/commander3/src/comm_tod_mapmaking_mod.f90
@@ -58,12 +58,14 @@ contains
     if (solve_S) then
        self%ncol = tod%nmaps + tod%ndet - 1
        self%n_A  = tod%nmaps*(tod%nmaps+1)/2 + 4*(tod%ndet-1)
-       self%nout = tod%output_n_maps + size(tod%bp_delta,2) - 1
+       self%nout = tod%output_n_maps + tod%n_bp_prop - 1
+       !write(*,*) 'hei!', size(tod%bp_delta,2)
     else
        self%ncol = tod%nmaps
        self%n_A  = tod%nmaps*(tod%nmaps+1)/2
        self%nout = tod%output_n_maps
     end if
+    !write(*,*) 'nout = ', tod%output_n_maps, self%nout
     allocate(self%outmaps(self%nout))
     do i = 1, self%nout
        self%outmaps(i)%p => comm_map(tod%info)
@@ -156,7 +158,7 @@ contains
     integer(i4b) :: det, i, t, pix_, off, nout, psi_
     real(dp)     :: inv_sigmasq
 
-    nout = binmap%nout
+    nout = size(data,1) 
     do det = 1, size(pix,2)
        if (.not. tod%scans(scan)%d(det)%accept) cycle
        off         = 6 + 4*(det-1)

--- a/commander3/src/comm_tod_mod.f90
+++ b/commander3/src/comm_tod_mod.f90
@@ -37,6 +37,7 @@ module comm_tod_mod
    byte, dimension(:), allocatable :: p 
   end type byte_pointer
 
+
   type :: comm_detscan
      character(len=10) :: label                             ! Detector label
      real(dp)          :: gain, dgain, gain_invsigma           ! Gain; assumed constant over scan
@@ -117,6 +118,9 @@ module comm_tod_mod
      integer(i4b) :: output_aux_maps                              ! Output auxiliary maps
      integer(i4b) :: halfring_split                               ! Type of halfring split 0=None, 1=HR1, 2=HR2
      logical(lgt) :: subtract_zodi                                ! Subtract zodical light
+     logical(lgt) :: correct_sl                                   ! Subtract sidelobes
+     logical(lgt) :: sample_mono                                  ! Subtract detector-specific monopoles
+     logical(lgt) :: orb_4pi_beam                                 ! Perform 4pi beam convolution for orbital CMB dipole 
      integer(i4b),       allocatable, dimension(:)     :: stokes  ! List of Stokes parameters
      real(dp),           allocatable, dimension(:,:,:) :: w       ! Stokes weights per detector per horn, (nmaps,nhorn,ndet)
      real(sp),           allocatable, dimension(:)     :: sin2psi  ! Lookup table of sin(2psi)

--- a/commander3/src/comm_tod_mod.f90
+++ b/commander3/src/comm_tod_mod.f90
@@ -248,6 +248,9 @@ contains
     self%central_freq  = cpar%ds_nu_c(id_abs)
     self%halfring_split= cpar%ds_tod_halfring(id_abs)
     self%nside_param   = cpar%ds_nside(id_abs)
+    self%verbosity     = cpar%verbosity
+    self%sims_output_dir = cpar%sims_output_dir
+    self%enable_tod_simulations = cpar%enable_tod_simulations
 
     call mpi_comm_size(cpar%comm_shared, self%numprocs_shared, ierr)
 
@@ -307,9 +310,9 @@ contains
     allocate(self%bp_delta(0:self%ndet,ndelta))
     self%bp_delta = 0.d0
 
-    ! Allocate orbital dipole object
-    allocate(self%orb_dp)
-    self%orb_dp => comm_orbdipole(self%mbeam)
+    ! Allocate orbital dipole object; this should go in the experiment files, since it must be done after beam init
+    !allocate(self%orb_dp)
+    !self%orb_dp => comm_orbdipole(self%mbeam)
 
   end subroutine tod_constructor
 

--- a/commander3/src/comm_tod_mod.f90
+++ b/commander3/src/comm_tod_mod.f90
@@ -756,7 +756,6 @@ contains
        end do
        close(unit)
 
-       write(*,*) 'n_tot = ', n_tot, self%first_scan, self%last_scan
        if (n_tot == 0) then
           write(*,*) 'Error: No accepted scans in filelist: ', trim(filelist)
           stop

--- a/commander3/src/comm_tod_orbdipole_mod.f90
+++ b/commander3/src/comm_tod_orbdipole_mod.f90
@@ -22,7 +22,6 @@ module comm_tod_orbdipole_mod
   use comm_utils
   use comm_defs
   use comm_map_mod
-  use comm_tod_mod
   use spline_1D_mod
   implicit none
 
@@ -30,21 +29,15 @@ module comm_tod_orbdipole_mod
   public comm_orbdipole, orbdipole_pointer
 
   type :: comm_orbdipole
-    real(dp),           allocatable, dimension(:, :) :: orb_dp_s !precomputed s integrals for orbital dipole sidelobe term
-    class(map_ptr), dimension(:), allocatable :: beam
-    class(comm_tod), pointer :: tod
+    integer(i4b) :: ndet, subsample
+    integer(i4b) :: comm, myid
+    real(dp),       dimension(:,:), allocatable :: orb_dp_s !precomputed s integrals for orbital dipole sidelobe term
+    class(map_ptr), dimension(:),   allocatable :: beam
     type(spline_type) :: s
-    integer(i4b) :: subsample
-
   contains
     procedure :: precompute_orb_dp_s
-    procedure :: compute_orbital_dipole_4pi
-    procedure :: compute_orbital_dipole_pencil
+    procedure :: compute_CMB_dipole
     procedure :: compute_4pi_product
-    procedure :: compute_solar_dipole_4pi
-    procedure :: compute_solar_dipole_pencil
-    procedure :: compute_4pi_product_sol
-
   end type comm_orbdipole
 
   interface comm_orbdipole
@@ -57,23 +50,24 @@ module comm_tod_orbdipole_mod
 
 contains
 
-  function constructor(tod, beam)
+  function constructor(beam)
     implicit none
-    class(comm_tod), target :: tod
     class(map_ptr), dimension(:), target :: beam
     class(comm_orbdipole), pointer :: constructor
     integer(i4b) :: i
-    allocate(constructor)
 
-    constructor%tod => tod
-    allocate(constructor%beam(constructor%tod%ndet))
-    do i=1, constructor%tod%ndet
+    allocate(constructor)
+    constructor%ndet      = size(beam)
+    constructor%subsample = 20
+    constructor%comm      = beam(1)%p%info%comm
+    constructor%myid      = beam(1)%p%info%myid
+
+    allocate(constructor%beam(constructor%ndet))
+    do i=1, constructor%ndet
       constructor%beam(i)%p => beam(i)%p
     end do
 
     call constructor%precompute_orb_dp_s()
-
-    constructor%subsample = 20
 
   end function constructor
 
@@ -85,11 +79,11 @@ contains
     real(dp), dimension(3) :: v
     real(dp) :: pixVal
 
-    allocate(self%orb_dp_s(self%tod%ndet, 10)) 
-    do i = 1, self%tod%ndet
+    allocate(self%orb_dp_s(self%ndet, 10)) 
+    do i = 1, self%ndet
       self%orb_dp_s(i, :) = 0
       do j = 0, self%beam(i)%p%info%np-1
-        call pix2vec_ring(self%beam(i)%p%info%nside, self%beam(i)%p%info%pix(j+1),v)
+         call pix2vec_ring(self%beam(i)%p%info%nside, self%beam(i)%p%info%pix(j+1),v)
          pixVal = self%beam(i)%p%map(j, 1)
          !if(pixVal < 0) then
          !   pixVal = 0.d0
@@ -109,11 +103,11 @@ contains
          !2xz 
          self%orb_dp_s(i, 6) = self%orb_dp_s(i, 6) + 2.d0 * pixVal* v(1) * v(3)
          !y^2 
-         self%orb_dp_s(i, 7) =self%orb_dp_s(i, 7)+pixVal*v(2)*v(2)
+         self%orb_dp_s(i, 7) = self%orb_dp_s(i, 7)+pixVal*v(2)*v(2)
          !2yz 
          self%orb_dp_s(i, 8) = self%orb_dp_s(i, 8) + 2.d0 * pixVal* v(2) * v(3)
          !z^2 
-         self%orb_dp_s(i, 9) =self%orb_dp_s(i, 9) + pixVal*v(3)*v(3)
+         self%orb_dp_s(i, 9) = self%orb_dp_s(i, 9) + pixVal*v(3)*v(3)
          !full beam integral for normalization
          self%orb_dp_s(i, 10) = self%orb_dp_s(i,10) + pixVal
          !if(self%myid == 38) then
@@ -122,9 +116,9 @@ contains
        end do
     end do
 
-   call mpi_allreduce(MPI_IN_PLACE, self%orb_dp_s, size(self%orb_dp_s), MPI_DOUBLE_PRECISION, MPI_SUM, self%tod%info%comm, ierr)
+   call mpi_allreduce(MPI_IN_PLACE, self%orb_dp_s, size(self%orb_dp_s), MPI_DOUBLE_PRECISION, MPI_SUM, self%comm, ierr)
 
-   do i = 1, self%tod%ndet
+   do i = 1, self%ndet
       self%orb_dp_s(i,:) = self%orb_dp_s(i,:)*4*pi/real(self%beam(i)%p%info%npix)
    end do
 
@@ -161,255 +155,92 @@ contains
 
   end subroutine precompute_orb_dp_s
 
-  subroutine compute_orbital_dipole_pencil(self, ind, pix, psi, s_orb, factor)
+  subroutine compute_CMB_dipole(self, det, v_ref, nu, &
+       & relativistic, beam_4pi, P, s_dip, factor)
     implicit none
-    class(comm_orbdipole),               intent(in)  :: self
-    integer(i4b),                        intent(in)  :: ind !scan nr/index
-    integer(i4b),        dimension(:),   intent(in)  :: pix, psi
-    real(sp),            dimension(:,:), intent(out) :: s_orb
-    real(dp),               intent(in), optional     :: factor
-    real(dp) :: b, x, q, b_dot, f
-    integer(i4b) :: i, j
+    class(comm_orbdipole),                 intent(inout)  :: self
+    integer(i4b),                          intent(in)  :: det
+    real(dp),                              intent(in)  :: v_ref(3), nu
+    logical(lgt),                          intent(in)  :: relativistic 
+    logical(lgt),                          intent(in)  :: beam_4pi
+    real(dp),            dimension(1:,1:), intent(in)  :: P
+    real(sp),            dimension(:),     intent(out) :: s_dip
+    real(sp),                              intent(in), optional :: factor
 
-    if (present(factor)) then 
-      f = factor
-    else
-      f = 1
-    end if
+    real(dp)     :: b, x, q, b_dot, f
+    integer(i4b) :: i, j, k, s_len, ntod
+    real(dp), dimension(:), allocatable :: x_vec, y_vec
 
-    b = sqrt(sum(self%tod%scans(ind)%v_sun**2))/c   ! beta for the given scan
-    x = h * self%tod%central_freq/(k_B * T_CMB)
+    f = 1.d0; if (present(factor)) f = factor
+    b = sqrt(sum(v_ref**2))/c   ! beta for the given scan
+    x = h * nu/(k_B * T_CMB)
     q = (x/2.d0)*(exp(x)+1)/(exp(x) -1)
+    ntod = size(s_dip)
 
-
-    do i = 1,self%tod%ndet
-       if (.not. self%tod%scans(ind)%d(i)%accept) then
-         s_orb(:,i) = 0
-         cycle
-       end if
-       do j=1,self%tod%scans(ind)%ntod !length of the tod
-          b_dot = dot_product(self%tod%scans(ind)%v_sun, self%tod%pix2vec(:,pix(j)))/c
-          s_orb(j,i) = f*T_CMB * (b_dot + q*(b_dot**2 - b**2/3.))
+    if (.not. beam_4pi) then
+       do i = 1, size(s_dip,1) !length of the tod
+          b_dot = dot_product(v_ref, P(:,i))/c
+          if (relativistic) then
+             s_dip(i) = f * T_CMB * (b_dot + q*(b_dot**2 - b**2/3.))
+          else
+             s_dip(i) = f * T_CMB *  b_dot
+          end if
        end do
-    end do
+    else 
+       s_len = ntod/self%subsample
+       allocate(x_vec(s_len), y_vec(s_len))
+       do k = 1, s_len !number of subsampled samples
+          j        = self%subsample * (k-1) + 1
+          X_vec(k) = j
+          y_vec(k) = self%compute_4pi_product(det, q, P(:,j), v_ref) 
+       end do
+       
+       !spline the subsampled dipole to the full resolution
+       call spline_simple(self%s, x_vec, y_vec, regular=.true.)
 
-  end subroutine compute_orbital_dipole_pencil
+       do i = 1, s_len*self%subsample
+         s_dip(i) = splint_simple(self%s, real(i,dp))
+       end do
 
-  subroutine compute_solar_dipole_pencil(self, ind, pix, s_sol, factor)
-    implicit none
-    class(comm_orbdipole),               intent(in)  :: self
-    integer(i4b),                        intent(in)  :: ind !scan nr/index
-    integer(i4b),        dimension(:),   intent(in)  :: pix
-    real(sp),            dimension(:),   intent(out) :: s_sol
-    real(sp),                            intent(in), optional :: factor
-    real(dp) :: b, x, q, b_dot, phi, theta
-    real(sp) :: f
-    real(dp), dimension(3) :: vnorm
-    integer(i4b) :: i, j
+       !handle the last irregular length bit of each chunk as a special case 
+       !so that we can use regular=true in the spline code for speed
+       do j=s_len*self%subsample+1, ntod
+         s_dip(j) = self%compute_4pi_product(det, q, P(:,j), v_ref) 
+       end do
 
-    if (.not. self%tod%scans(ind)%d(i)%accept) then
-       s_sol = 0
-       return
+       deallocate(x_vec, y_vec)
+       call free_spline(self%s)
     end if
 
-    f = 1.; if (present(factor)) f = factor
-    phi   = 4.607145626489432  ! 263.97*pi/180
-    theta = 0.7278022980816355 ! (90-48.3)*pi/180
-    vnorm = (/ sin(theta)*cos(phi), sin(theta)*sin(phi), cos(theta) /)
+  end subroutine compute_CMB_dipole
 
-    do j=1,self%tod%scans(ind)%ntod !length of the tod
-       b_dot = dot_product(vnorm, self%tod%pix2vec(:,pix(j)))
-       s_sol(j) = f * T_CMB_DIP * b_dot
-    end do
-  end subroutine compute_solar_dipole_pencil
 
-  function compute_4pi_product(self, p, psiInd, chunkInd, i, q) result(prod)
+  function compute_4pi_product(self, det, q, Pang, v_ref) result(prod)
     implicit none
     class(comm_orbdipole), intent(in) :: self
-    integer(i4b),          intent(in) :: p, psiInd, chunkInd, i
-    real(dp),              intent(in) :: q
+    integer(i4b),          intent(in) :: det
+    real(dp),              intent(in) :: q, Pang(3), v_ref(3)
     real(dp)                          :: prod
 
-    real(dp) :: theta, psi_d, phi
     real(dp), dimension(3,3) :: rot_mat
     real(dp), dimension(3)   :: vnorm
 
-    theta = self%tod%ind2ang(1,p)
-    phi   = self%tod%ind2ang(2,p)
-    psi_d = self%tod%psi(psiInd)
-    !write(*,*), j, phi, theta, psi_d, rot_mat 
-    call compute_euler_matrix_zyz(-psi_d, -theta, -phi, rot_mat)
-    vnorm = matmul(rot_mat, self%tod%scans(chunkInd)%v_sun)
-    vnorm = vnorm / c
-    ! Equation C.5 in NPIPE paper
-    prod = vnorm(1)*self%orb_dp_s(i,1)+ &
-          &vnorm(2)*self%orb_dp_s(i,2)+ &
-          &vnorm(3)*self%orb_dp_s(i,3)+ &
-          & q*(vnorm(1)*vnorm(1)*self%orb_dp_s(i,4) + &
-          &    vnorm(1)*vnorm(2)*self%orb_dp_s(i,5) + &
-          &    vnorm(1)*vnorm(3)*self%orb_dp_s(i,6) + &
-          &    vnorm(2)*vnorm(2)*self%orb_dp_s(i,7) + &
-          &    vnorm(2)*vnorm(3)*self%orb_dp_s(i,8) + &
-          &    vnorm(3)*vnorm(3)*self%orb_dp_s(i,9))
+    call compute_euler_matrix_zyz(-Pang(3), -Pang(2), -Pang(1), rot_mat)
+    vnorm = matmul(rot_mat, v_ref) / c
 
-    prod = T_CMB*prod/self%orb_dp_s(i,10)
+    ! Equation C.5 in NPIPE paper
+    prod = vnorm(1)*self%orb_dp_s(det,1)+ &
+          &vnorm(2)*self%orb_dp_s(det,2)+ &
+          &vnorm(3)*self%orb_dp_s(det,3)+ &
+          & q*(vnorm(1)*vnorm(1)*self%orb_dp_s(det,4) + &
+          &    vnorm(1)*vnorm(2)*self%orb_dp_s(det,5) + &
+          &    vnorm(1)*vnorm(3)*self%orb_dp_s(det,6) + &
+          &    vnorm(2)*vnorm(2)*self%orb_dp_s(det,7) + &
+          &    vnorm(2)*vnorm(3)*self%orb_dp_s(det,8) + &
+          &    vnorm(3)*vnorm(3)*self%orb_dp_s(det,9))
+
+    prod = T_CMB*prod/self%orb_dp_s(det,10)
 
   end function compute_4pi_product
 
-  function compute_4pi_product_sol(self, p, psiInd, chunkInd, i, q) result(prod)
-    implicit none
-    class(comm_orbdipole), intent(in) :: self
-    integer(i4b),          intent(in) :: p, psiInd, chunkInd, i
-    real(dp),              intent(in) :: q
-    real(dp)                          :: prod
-
-    real(dp) :: theta, psi_d, phi
-    real(dp), dimension(3,3) :: rot_mat
-    real(dp), dimension(3)   :: vnorm
-    real(dp), dimension(3)   :: T_dip
-
-    phi   = 4.607145626489432  ! 263.97*pi/180
-    theta = 0.7278022980816355 ! (90-48.3)*pi/180
-    vnorm = (/ sin(theta)*cos(phi), sin(theta)*sin(phi), cos(theta) /)
-
-    theta = self%tod%ind2ang(1,p)
-    phi   = self%tod%ind2ang(2,p)
-    psi_d = self%tod%psi(psiInd)
-    !write(*,*), j, phi, theta, psi_d, rot_mat 
-    call compute_euler_matrix_zyz(-psi_d, -theta, -phi, rot_mat)
-    vnorm = matmul(rot_mat, vnorm)
-    ! Equation C.5 in NPIPE paper
-    prod = vnorm(1)*self%orb_dp_s(i,1)+ &
-          &vnorm(2)*self%orb_dp_s(i,2)+ &
-          &vnorm(3)*self%orb_dp_s(i,3)+ &
-          & q*(vnorm(1)*vnorm(1)*self%orb_dp_s(i,4) + &
-          &    vnorm(1)*vnorm(2)*self%orb_dp_s(i,5) + &
-          &    vnorm(1)*vnorm(3)*self%orb_dp_s(i,6) + &
-          &    vnorm(2)*vnorm(2)*self%orb_dp_s(i,7) + &
-          &    vnorm(2)*vnorm(3)*self%orb_dp_s(i,8) + &
-          &    vnorm(3)*vnorm(3)*self%orb_dp_s(i,9))
-
-    prod = T_CMB_DIP*prod/self%orb_dp_s(i,10)
-
-  end function compute_4pi_product_sol
-
-  ! Compute map with white noise assumption from correlated noise 
-  ! corrected and calibrated data, d' = (d-n_corr-n_temp)/gain 
-  subroutine compute_orbital_dipole_4pi(self, ind, pix, psi, s_orb)
-    implicit none
-    class(comm_orbdipole),               intent(inout)  :: self
-    integer(i4b),                        intent(in)  :: ind !scan nr/index
-    integer(i4b),        dimension(:,:), intent(in)  :: pix, psi
-    real(sp),            dimension(:,:), intent(out) :: s_orb
-    integer(i4b)         :: i, j, p, s_len, k, psiInd
-    real(dp)             :: x, T_0, q, pix_dir(3), b, b_dot, summation, j_real
-    real(dp), parameter  :: h = 6.62607015d-34   ! Planck's constant [Js]
-    real(dp), dimension(:), allocatable :: x_vec, y_vec
-
-    !these are the npipe paper definitions
-    !TODO: maybe also use the bandpass shift to modify the central frequency? 
-    !will that matter?
-    x = h * self%tod%central_freq/(k_B * T_CMB)
-    q = (x/2.d0)*(exp(x)+1)/(exp(x) -1)
-
-    do i = 1,self%tod%ndet
-       if (.not. self%tod%scans(ind)%d(i)%accept) cycle
-       s_len = self%tod%scans(ind)%ntod/self%subsample
-       allocate(x_vec(s_len), y_vec(s_len))
-       do k=0,s_len-1 !number of subsampled samples
-          j = (self%subsample * k) + 1
-
-          p      = self%tod%pix2ind(pix(j,i))
-          psiInd = psi(j,i)
-
-          summation = self%compute_4pi_product(p, psiInd, ind, i, q)
-          x_vec(k+1) = j
-          y_vec(k+1) = summation
-       end do
-       
-       !spline the subsampled dipole to the full resolution
-       call spline_simple(self%s, x_vec, y_vec, regular=.true.)
-
-       do j=1, s_len*self%subsample
-         j_real = j
-         s_orb(j,i) = splint_simple(self%s, j_real)
-       end do
-
-       !handle the last irregular length bit of each chunk as a special case 
-       !so that we can use regular=true in the spline code for speed
-       do j=s_len*self%subsample, self%tod%scans(ind)%ntod
-         p      = self%tod%pix2ind(pix(j,i))
-         psiInd = psi(j,i)
-         
-         s_orb(j,i) = self%compute_4pi_product(p, psiInd, ind, i, q)
-
-       end do
-
-       deallocate(x_vec, y_vec)
-   end do
-
-   call free_spline(self%s)
-   
-   !if (trim(self%tod%label(1)) == '27M') then
-   ! close(58)
-   ! close(59)
-   !end if
-  end subroutine compute_orbital_dipole_4pi
-
-  subroutine compute_solar_dipole_4pi(self, ind, pix, psi, s_sol)
-    implicit none
-    class(comm_orbdipole),               intent(inout)  :: self
-    integer(i4b),                        intent(in)  :: ind !scan nr/index
-    integer(i4b),        dimension(:,:), intent(in)  :: pix, psi
-    real(sp),            dimension(:,:), intent(out) :: s_sol
-    integer(i4b)         :: i, j, p, s_len, k, psiInd
-    real(dp)             :: x, T_0, q, pix_dir(3), b, b_dot, summation, j_real
-    real(dp), parameter  :: h = 6.62607015d-34   ! Planck's constant [Js]
-    real(dp), dimension(:), allocatable :: x_vec, y_vec
-
-    !these are the npipe paper definitions
-    !TODO: maybe also use the bandpass shift to modify the central frequency? 
-    !will that matter?
-    x = h * self%tod%central_freq/(k_B * T_CMB)
-    q = (x/2.d0)*(exp(x)+1)/(exp(x) -1)
-
-    do i = 1,self%tod%ndet
-       if (.not. self%tod%scans(ind)%d(i)%accept) cycle
-       s_len = self%tod%scans(ind)%ntod/self%subsample
-       allocate(x_vec(s_len), y_vec(s_len))
-       do k=0,s_len-1 !number of subsampled samples
-          j = (self%subsample * k) + 1
-
-          p      = self%tod%pix2ind(pix(j,i))
-          psiInd = psi(j,i)
-
-          summation = self%compute_4pi_product_sol(p, psiInd, ind, i, q)
-          x_vec(k+1) = j
-          y_vec(k+1) = summation
-       end do
-       
-       !spline the subsampled dipole to the full resolution
-       call spline_simple(self%s, x_vec, y_vec, regular=.true.)
-
-       do j=1, s_len*self%subsample
-         j_real = j
-         s_sol(j,i) = splint_simple(self%s, j_real)
-       end do
-
-       !handle the last irregular length bit of each chunk as a special case 
-       !so that we can use regular=true in the spline code for speed
-       do j=s_len*self%subsample, self%tod%scans(ind)%ntod
-         p      = self%tod%pix2ind(pix(j,i))
-         psiInd = psi(j,i)
-         
-         s_sol(j,i) = self%compute_4pi_product_sol(p, psiInd, ind, i, q)
-
-       end do
-
-       deallocate(x_vec, y_vec)
-   end do
-
-   call free_spline(self%s)
-   
-  end subroutine compute_solar_dipole_4pi
 end module comm_tod_orbdipole_mod

--- a/commander3/src/comm_tod_pointing_mod.f90
+++ b/commander3/src/comm_tod_pointing_mod.f90
@@ -31,7 +31,7 @@ contains
         & s_sky, tmask, s_bp)
       implicit none
       class(comm_tod),                   intent(in)             :: tod
-      integer(i4b), dimension(0:),       intent(in)             :: pmask
+      real(sp),     dimension(0:),       intent(in)             :: pmask
       real(sp),     dimension(1:,1:,0:), intent(in)             :: map
       integer(i4b), dimension(:,:),      intent(in)             :: pix, psi
       integer(i4b), dimension(:,:),      intent(in)             :: flag
@@ -85,18 +85,17 @@ contains
       implicit none
       !class(comm_tod), intent(in)  :: tod
       ! It is only inout for simulating data
-      class(comm_tod), intent(inout)  :: tod
-      integer(i4b), dimension(0:), intent(in)  :: pmask
-      real(sp), dimension(1:, 1:, 0:), intent(in)  :: map
-      !type(shared_2d_sp),  dimension(0:),     intent(in)  :: map
-      integer(i4b), dimension(:, :), intent(in)  :: pix, psi
-      integer(i4b), dimension(:), intent(in)  :: flag
-      integer(i4b), intent(in)  :: scan_id
-      real(sp), dimension(:, :), intent(out) :: s_skyA, s_skyB, tmask
-      real(sp), dimension(:, :), intent(out), optional :: s_bpA, s_bpB
+      class(comm_tod),                      intent(inout)  :: tod
+      real(sp),        dimension(0:),       intent(in)     :: pmask
+      real(sp),        dimension(1:,1:,0:), intent(in)     :: map
+      integer(i4b),    dimension(:,:),      intent(in)     :: pix, psi
+      integer(i4b),    dimension(:),        intent(in)     :: flag
+      integer(i4b),                         intent(in)     :: scan_id
+      real(sp),        dimension(:,:),      intent(out)    :: s_skyA, s_skyB, tmask
+      real(sp),        dimension(:,:),      intent(out), optional :: s_bpA, s_bpB
 
       integer(i4b) :: i, j, lpoint, rpoint, det
-      real(sp)                                          :: sA, sB, tr, pr, tl, pl
+      real(sp)     :: sA, sB, tr, pr, tl, pl
       real(sp), dimension(4) :: sgn=[1., 1., -1., -1.]
 
 

--- a/commander3/src/comm_tod_pointing_mod.f90
+++ b/commander3/src/comm_tod_pointing_mod.f90
@@ -44,22 +44,30 @@ contains
 
       ! s = T + Q * cos(2 * psi) + U * sin(2 * psi)
       ! T - temperature; Q, U - Stoke's parameters
+!      if (tod%myid == 78) write(*,*) 'c611', tod%myid, tod%correct_sl, tod%ndet, tod%slconv(1)%p%psires
       do det = 1, tod%ndet
+!         if (tod%myid == 78) write(*,*) 'c6111', tod%myid, tod%correct_sl, tod%ndet, tod%slconv(1)%p%psires
          if (.not. tod%scans(scan_id)%d(det)%accept) then
             s_sky(:, det) = 0.d0
             tmask(:, det) = 0.d0
             cycle
          end if
+         !if (tod%myid == 78) write(*,*) 'c6112', tod%myid, tod%correct_sl, tod%ndet, tod%slconv(1)%p%psires
          do i = 1, tod%scans(scan_id)%ntod
             p = tod%pix2ind(pix(i,det))
+            !if (tod%myid == 78 .and. p == 7863) write(*,*) 'c61121', tod%myid, tod%correct_sl, tod%ndet, tod%slconv(1)%p%psires, i, p
             s_sky(i,det) = map(1,p,det) + &
                          & map(2,p,det) * tod%cos2psi(psi(i,det)) + &
                          & map(3,p,det) * tod%sin2psi(psi(i,det))
-
+            !if (tod%myid == 78 .and. p == 7863) write(*,*) 'c61122', tod%myid, tod%correct_sl, tod%ndet, tod%slconv(1)%p%psires, i, p
             tmask(i,det) = pmask(pix(i,det))
+            !if (tod%myid == 78 .and. p == 7863) write(*,*) 'c61123', tod%myid, tod%correct_sl, tod%ndet, tod%slconv(1)%p%psires, i, p
             if (iand(flag(i,det), tod%flag0) .ne. 0) tmask(i,det) = 0.
+            !if (tod%myid == 78 .and. p == 7863) write(*,*) 'c61124', tod%myid, tod%correct_sl, tod%ndet, tod%slconv(1)%p%psires, i, p
          end do
+         !if (tod%myid == 78) write(*,*) 'c6113', tod%myid, tod%correct_sl, tod%ndet, tod%slconv(1)%p%psires
       end do
+      !if (tod%myid == 78) write(*,*) 'c612', tod%myid, tod%correct_sl, tod%ndet, tod%slconv(1)%p%psires
 
       if (present(s_bp)) then
          do det = 1, tod%ndet
@@ -76,6 +84,7 @@ contains
             end do
          end do
       end if
+      !if (tod%myid == 78) write(*,*) 'c613', tod%myid, tod%correct_sl, tod%ndet, tod%slconv(1)%p%psires
 
    end subroutine project_sky
 

--- a/commander3/src/comm_tod_simulations_mod.f90
+++ b/commander3/src/comm_tod_simulations_mod.f90
@@ -16,7 +16,7 @@ module comm_tod_simulations_mod
   use spline_1D_mod
   use comm_param_mod
   use comm_utils
-  use comm_tod_LFI_mod
+  !use comm_tod_LFI_mod
   implicit none
 
 contains


### PR DESCRIPTION
The instrument-specific LFI module has been modularized and streamlined. 

KNOWN BUG: When running with bandpass sampling turned on (TOD_NUM_BP_PROPOSALS_PER_ITER > 0), the sidelobe memory structure becomes corrupted during the project_sky operation for the bandpass correction TODs, and the code crashes during sidelobe interpolation. For now, run without bandpass sampling, and then we'll fix that later.