### PR TITLE
Support for instrument specific TOD IO routines

### DIFF
--- a/commander3/src/comm_tod_LB_mod.f90
+++ b/commander3/src/comm_tod_LB_mod.f90
@@ -53,6 +53,8 @@ module comm_tod_LB_mod
   type, extends(comm_tod) :: comm_LB_tod
    contains
      procedure     :: process_tod        => process_LB_tod
+     procedure     :: read_tod_inst      => read_tod_inst_LB
+     procedure     :: read_scan_inst     => read_scan_inst_LB
   end type comm_LB_tod
 
   interface comm_LB_tod
@@ -417,5 +419,56 @@ contains
     call update_status(status, "tod_end"//ctext)
 
   end subroutine process_LB_tod   
+
+
+
+  subroutine read_tod_inst_LB(self, file)
+    ! 
+    ! Reads LB-specific common fields from TOD fileset
+    ! 
+    ! Arguments:
+    ! ----------
+    ! self:     derived class (comm_LB_tod)
+    !           LB-specific TOD object
+    ! file:     derived type (hdf_file)
+    !           Already open HDF file handle; only root includes this
+    !
+    ! Returns
+    ! ----------
+    ! None, but updates self
+    !
+    implicit none
+    class(comm_LB_tod),                  intent(inout)          :: self
+    type(hdf_file),                      intent(in),   optional :: file
+  end subroutine read_tod_inst_LB
+  
+  subroutine read_scan_inst_LB(self, file, slabel, detlabels, scan)
+    ! 
+    ! Reads LB-specific scan information from TOD fileset
+    ! 
+    ! Arguments:
+    ! ----------
+    ! self:     derived class (comm_LB_tod)
+    !           LB-specific TOD object
+    ! file:     derived type (hdf_file)
+    !           Already open HDF file handle
+    ! slabel:   string
+    !           Scan label, e.g., "000001/"
+    ! detlabels: string (array)
+    !           Array of detector labels, e.g., ["27M", "27S"]
+    ! scan:     derived class (comm_scan)
+    !           Scan object
+    !
+    ! Returns
+    ! ----------
+    ! None, but updates scan object
+    !
+    implicit none
+    class(comm_LB_tod),                  intent(in)    :: self
+    type(hdf_file),                      intent(in)    :: file
+    character(len=*),                    intent(in)    :: slabel
+    character(len=*), dimension(:),      intent(in)    :: detlabels
+    class(comm_scan),                    intent(inout) :: scan
+  end subroutine read_scan_inst_LB
 
 end module comm_tod_LB_mod

--- a/commander3/src/comm_tod_LB_mod.f90
+++ b/commander3/src/comm_tod_LB_mod.f90
@@ -55,6 +55,8 @@ module comm_tod_LB_mod
      procedure     :: process_tod        => process_LB_tod
      procedure     :: read_tod_inst      => read_tod_inst_LB
      procedure     :: read_scan_inst     => read_scan_inst_LB
+     procedure     :: initHDF_inst       => initHDF_LB
+     procedure     :: dumpToHDF_inst     => dumpToHDF_LB
   end type comm_LB_tod
 
   interface comm_LB_tod
@@ -470,5 +472,52 @@ contains
     character(len=*), dimension(:),      intent(in)    :: detlabels
     class(comm_scan),                    intent(inout) :: scan
   end subroutine read_scan_inst_LB
+
+  subroutine initHDF_LB(self, chainfile, path)
+    ! 
+    ! Initializes LB-specific TOD parameters from existing chain file
+    ! 
+    ! Arguments:
+    ! ----------
+    ! self:     derived class (comm_LB_tod)
+    !           LB-specific TOD object
+    ! chainfile: derived type (hdf_file)
+    !           Already open HDF file handle to existing chainfile
+    ! path:   string
+    !           HDF path to current dataset, e.g., "000001/tod/030"
+    !
+    ! Returns
+    ! ----------
+    ! None
+    !
+    implicit none
+    class(comm_LB_tod),                  intent(inout)  :: self
+    type(hdf_file),                      intent(in)     :: chainfile
+    character(len=*),                    intent(in)     :: path
+  end subroutine initHDF_LB
+  
+  subroutine dumpToHDF_LB(self, chainfile, path)
+    ! 
+    ! Writes LB-specific TOD parameters to existing chain file
+    ! 
+    ! Arguments:
+    ! ----------
+    ! self:     derived class (comm_LB_tod)
+    !           LB-specific TOD object
+    ! chainfile: derived type (hdf_file)
+    !           Already open HDF file handle to existing chainfile
+    ! path:   string
+    !           HDF path to current dataset, e.g., "000001/tod/030"
+    !
+    ! Returns
+    ! ----------
+    ! None
+    !
+    implicit none
+    class(comm_LB_tod),                  intent(in)     :: self
+    type(hdf_file),                      intent(in)     :: chainfile
+    character(len=*),                    intent(in)     :: path
+  end subroutine dumpToHDF_LB
+
 
 end module comm_tod_LB_mod

--- a/commander3/src/comm_tod_LFI_mod.f90
+++ b/commander3/src/comm_tod_LFI_mod.f90
@@ -54,6 +54,8 @@ module comm_tod_LFI_mod
      procedure     :: process_tod        => process_LFI_tod
      procedure     :: read_tod_inst      => read_tod_inst_LFI
      procedure     :: read_scan_inst     => read_scan_inst_LFI
+     procedure     :: initHDF_inst       => initHDF_LFI
+     procedure     :: dumpToHDF_inst     => dumpToHDF_LFI
   end type comm_LFI_tod
 
   interface comm_LFI_tod
@@ -466,5 +468,51 @@ contains
     character(len=*), dimension(:),      intent(in)    :: detlabels
     class(comm_scan),                    intent(inout) :: scan
   end subroutine read_scan_inst_LFI
+
+  subroutine initHDF_LFI(self, chainfile, path)
+    ! 
+    ! Initializes LFI-specific TOD parameters from existing chain file
+    ! 
+    ! Arguments:
+    ! ----------
+    ! self:     derived class (comm_LFI_tod)
+    !           LFI-specific TOD object
+    ! chainfile: derived type (hdf_file)
+    !           Already open HDF file handle to existing chainfile
+    ! path:   string
+    !           HDF path to current dataset, e.g., "000001/tod/030"
+    !
+    ! Returns
+    ! ----------
+    ! None
+    !
+    implicit none
+    class(comm_LFI_tod),                 intent(inout)  :: self
+    type(hdf_file),                      intent(in)     :: chainfile
+    character(len=*),                    intent(in)     :: path
+  end subroutine initHDF_LFI
+  
+  subroutine dumpToHDF_LFI(self, chainfile, path)
+    ! 
+    ! Writes LFI-specific TOD parameters to existing chain file
+    ! 
+    ! Arguments:
+    ! ----------
+    ! self:     derived class (comm_LFI_tod)
+    !           LFI-specific TOD object
+    ! chainfile: derived type (hdf_file)
+    !           Already open HDF file handle to existing chainfile
+    ! path:   string
+    !           HDF path to current dataset, e.g., "000001/tod/030"
+    !
+    ! Returns
+    ! ----------
+    ! None
+    !
+    implicit none
+    class(comm_LFI_tod),                 intent(in)     :: self
+    type(hdf_file),                      intent(in)     :: chainfile
+    character(len=*),                    intent(in)     :: path
+  end subroutine dumpToHDF_LFI
 
 end module comm_tod_LFI_mod

--- a/commander3/src/comm_tod_LFI_mod.f90
+++ b/commander3/src/comm_tod_LFI_mod.f90
@@ -52,6 +52,8 @@ module comm_tod_LFI_mod
   type, extends(comm_tod) :: comm_LFI_tod
    contains
      procedure     :: process_tod        => process_LFI_tod
+     procedure     :: read_tod_inst      => read_tod_inst_LFI
+     procedure     :: read_scan_inst     => read_scan_inst_LFI
   end type comm_LFI_tod
 
   interface comm_LFI_tod
@@ -414,5 +416,55 @@ contains
     call update_status(status, "tod_end"//ctext)
 
   end subroutine process_LFI_tod
+
+  
+  subroutine read_tod_inst_LFI(self, file)
+    ! 
+    ! Reads LFI-specific common fields from TOD fileset
+    ! 
+    ! Arguments:
+    ! ----------
+    ! self:     derived class (comm_LFI_tod)
+    !           LFI-specific TOD object
+    ! file:     derived type (hdf_file)
+    !           Already open HDF file handle; only root includes this
+    !
+    ! Returns
+    ! ----------
+    ! None, but updates self
+    !
+    implicit none
+    class(comm_LFI_tod),                 intent(inout)          :: self
+    type(hdf_file),                      intent(in),   optional :: file
+  end subroutine read_tod_inst_LFI
+  
+  subroutine read_scan_inst_LFI(self, file, slabel, detlabels, scan)
+    ! 
+    ! Reads LFI-specific scan information from TOD fileset
+    ! 
+    ! Arguments:
+    ! ----------
+    ! self:     derived class (comm_LFI_tod)
+    !           LFI-specific TOD object
+    ! file:     derived type (hdf_file)
+    !           Already open HDF file handle
+    ! slabel:   string
+    !           Scan label, e.g., "000001/"
+    ! detlabels: string (array)
+    !           Array of detector labels, e.g., ["27M", "27S"]
+    ! scan:     derived class (comm_scan)
+    !           Scan object
+    !
+    ! Returns
+    ! ----------
+    ! None, but updates scan object
+    !
+    implicit none
+    class(comm_LFI_tod),                 intent(in)    :: self
+    type(hdf_file),                      intent(in)    :: file
+    character(len=*),                    intent(in)    :: slabel
+    character(len=*), dimension(:),      intent(in)    :: detlabels
+    class(comm_scan),                    intent(inout) :: scan
+  end subroutine read_scan_inst_LFI
 
 end module comm_tod_LFI_mod

--- a/commander3/src/comm_tod_SPIDER_mod.f90
+++ b/commander3/src/comm_tod_SPIDER_mod.f90
@@ -52,6 +52,8 @@ module comm_tod_SPIDER_mod
      procedure     :: process_tod        => process_SPIDER_tod
      procedure     :: read_tod_inst      => read_tod_inst_SPIDER
      procedure     :: read_scan_inst     => read_scan_inst_SPIDER
+     procedure     :: initHDF_inst       => initHDF_SPIDER
+     procedure     :: dumpToHDF_inst     => dumpToHDF_SPIDER
   end type comm_SPIDER_tod
 
   interface comm_SPIDER_tod
@@ -1552,6 +1554,52 @@ subroutine write2file(filename, iter, param)
     character(len=*), dimension(:),      intent(in)    :: detlabels
     class(comm_scan),                    intent(inout) :: scan
   end subroutine read_scan_inst_SPIDER
+
+  subroutine initHDF_SPIDER(self, chainfile, path)
+    ! 
+    ! Initializes SPIDER-specific TOD parameters from existing chain file
+    ! 
+    ! Arguments:
+    ! ----------
+    ! self:     derived class (comm_SPIDER_tod)
+    !           SPIDER-specific TOD object
+    ! chainfile: derived type (hdf_file)
+    !           Already open HDF file handle to existing chainfile
+    ! path:   string
+    !           HDF path to current dataset, e.g., "000001/tod/030"
+    !
+    ! Returns
+    ! ----------
+    ! None
+    !
+    implicit none
+    class(comm_SPIDER_tod),              intent(inout)  :: self
+    type(hdf_file),                      intent(in)     :: chainfile
+    character(len=*),                    intent(in)     :: path
+  end subroutine initHDF_SPIDER
+  
+  subroutine dumpToHDF_SPIDER(self, chainfile, path)
+    ! 
+    ! Writes SPIDER-specific TOD parameters to existing chain file
+    ! 
+    ! Arguments:
+    ! ----------
+    ! self:     derived class (comm_SPIDER_tod)
+    !           SPIDER-specific TOD object
+    ! chainfile: derived type (hdf_file)
+    !           Already open HDF file handle to existing chainfile
+    ! path:   string
+    !           HDF path to current dataset, e.g., "000001/tod/030"
+    !
+    ! Returns
+    ! ----------
+    ! None
+    !
+    implicit none
+    class(comm_SPIDER_tod),              intent(in)     :: self
+    type(hdf_file),                      intent(in)     :: chainfile
+    character(len=*),                    intent(in)     :: path
+  end subroutine dumpToHDF_SPIDER
 
 
 

--- a/commander3/src/comm_tod_SPIDER_mod.f90
+++ b/commander3/src/comm_tod_SPIDER_mod.f90
@@ -50,6 +50,8 @@ module comm_tod_SPIDER_mod
      !class(orbdipole_pointer), allocatable :: orb_dp !orbital dipole calculator
    contains
      procedure     :: process_tod        => process_SPIDER_tod
+     procedure     :: read_tod_inst      => read_tod_inst_SPIDER
+     procedure     :: read_scan_inst     => read_scan_inst_SPIDER
   end type comm_SPIDER_tod
 
   interface comm_SPIDER_tod
@@ -1500,6 +1502,56 @@ subroutine write2file(filename, iter, param)
 
    close(unit)
  end subroutine write2file
+
+
+  subroutine read_tod_inst_SPIDER(self, file)
+    ! 
+    ! Reads SPIDER-specific common fields from TOD fileset
+    ! 
+    ! Arguments:
+    ! ----------
+    ! self:     derived class (comm_SPIDER_tod)
+    !           SPIDER-specific TOD object
+    ! file:     derived type (hdf_file)
+    !           Already open HDF file handle; only root includes this
+    !
+    ! Returns
+    ! ----------
+    ! None, but updates self
+    !
+    implicit none
+    class(comm_SPIDER_tod),              intent(inout)          :: self
+    type(hdf_file),                      intent(in),   optional :: file
+  end subroutine read_tod_inst_SPIDER
+  
+  subroutine read_scan_inst_SPIDER(self, file, slabel, detlabels, scan)
+    ! 
+    ! Reads SPIDER-specific scan information from TOD fileset
+    ! 
+    ! Arguments:
+    ! ----------
+    ! self:     derived class (comm_SPIDER_tod)
+    !           SPIDER-specific TOD object
+    ! file:     derived type (hdf_file)
+    !           Already open HDF file handle
+    ! slabel:   string
+    !           Scan label, e.g., "000001/"
+    ! detlabels: string (array)
+    !           Array of detector labels, e.g., ["27M", "27S"]
+    ! scan:     derived class (comm_scan)
+    !           Scan object
+    !
+    ! Returns
+    ! ----------
+    ! None, but updates scan object
+    !
+    implicit none
+    class(comm_SPIDER_tod),              intent(in)    :: self
+    type(hdf_file),                      intent(in)    :: file
+    character(len=*),                    intent(in)    :: slabel
+    character(len=*), dimension(:),      intent(in)    :: detlabels
+    class(comm_scan),                    intent(inout) :: scan
+  end subroutine read_scan_inst_SPIDER
 
 
 

--- a/commander3/src/comm_tod_WMAP_mod.f90
+++ b/commander3/src/comm_tod_WMAP_mod.f90
@@ -71,7 +71,9 @@ module comm_tod_WMAP_mod
       !class(orbdipole_pointer), allocatable :: orb_dp ! orbital dipole calculator
       character(len=20), allocatable, dimension(:) :: labels ! names of fields
    contains
-      procedure     :: process_tod => process_WMAP_tod
+      procedure     :: process_tod    => process_WMAP_tod
+      procedure     :: read_tod_inst  => read_tod_inst_WMAP
+      procedure     :: read_scan_inst => read_scan_inst_WMAP
    end type comm_WMAP_tod
 
    interface comm_WMAP_tod
@@ -1194,5 +1196,56 @@ contains
     deallocate(residual, r_fill)
 
   end subroutine accumulate_imbal_cal
+
+
+  subroutine read_tod_inst_WMAP(self, file)
+    ! 
+    ! Reads WMAP-specific common fields from TOD fileset
+    ! 
+    ! Arguments:
+    ! ----------
+    ! self:     derived class (comm_WMAP_tod)
+    !           WMAP-specific TOD object
+    ! file:     derived type (hdf_file)
+    !           Already open HDF file handle; only root includes this
+    !
+    ! Returns
+    ! ----------
+    ! None, but updates self
+    !
+    implicit none
+    class(comm_WMAP_tod),                intent(inout)          :: self
+    type(hdf_file),                      intent(in),   optional :: file
+  end subroutine read_tod_inst_WMAP
+  
+  subroutine read_scan_inst_WMAP(self, file, slabel, detlabels, scan)
+    ! 
+    ! Reads WMAP-specific scan information from TOD fileset
+    ! 
+    ! Arguments:
+    ! ----------
+    ! self:     derived class (comm_WMAP_tod)
+    !           WMAP-specific TOD object
+    ! file:     derived type (hdf_file)
+    !           Already open HDF file handle
+    ! slabel:   string
+    !           Scan label, e.g., "000001/"
+    ! detlabels: string (array)
+    !           Array of detector labels, e.g., ["27M", "27S"]
+    ! scan:     derived class (comm_scan)
+    !           Scan object
+    !
+    ! Returns
+    ! ----------
+    ! None, but updates scan object
+    !
+    implicit none
+    class(comm_WMAP_tod),                intent(in)    :: self
+    type(hdf_file),                      intent(in)    :: file
+    character(len=*),                    intent(in)    :: slabel
+    character(len=*), dimension(:),      intent(in)    :: detlabels
+    class(comm_scan),                    intent(inout) :: scan
+  end subroutine read_scan_inst_WMAP
+
 
 end module comm_tod_WMAP_mod

--- a/commander3/src/comm_tod_WMAP_mod.f90
+++ b/commander3/src/comm_tod_WMAP_mod.f90
@@ -74,6 +74,8 @@ module comm_tod_WMAP_mod
       procedure     :: process_tod    => process_WMAP_tod
       procedure     :: read_tod_inst  => read_tod_inst_WMAP
       procedure     :: read_scan_inst => read_scan_inst_WMAP
+      procedure     :: initHDF_inst   => initHDF_WMAP
+      procedure     :: dumpToHDF_inst => dumpToHDF_WMAP
    end type comm_WMAP_tod
 
    interface comm_WMAP_tod
@@ -1246,6 +1248,52 @@ contains
     character(len=*), dimension(:),      intent(in)    :: detlabels
     class(comm_scan),                    intent(inout) :: scan
   end subroutine read_scan_inst_WMAP
+
+  subroutine initHDF_WMAP(self, chainfile, path)
+    ! 
+    ! Initializes WMAP-specific TOD parameters from existing chain file
+    ! 
+    ! Arguments:
+    ! ----------
+    ! self:     derived class (comm_WMAP_tod)
+    !           WMAP-specific TOD object
+    ! chainfile: derived type (hdf_file)
+    !           Already open HDF file handle to existing chainfile
+    ! path:   string
+    !           HDF path to current dataset, e.g., "000001/tod/030"
+    !
+    ! Returns
+    ! ----------
+    ! None
+    !
+    implicit none
+    class(comm_WMAP_tod),                intent(inout)  :: self
+    type(hdf_file),                      intent(in)     :: chainfile
+    character(len=*),                    intent(in)     :: path
+  end subroutine initHDF_WMAP
+  
+  subroutine dumpToHDF_WMAP(self, chainfile, path)
+    ! 
+    ! Writes WMAP-specific TOD parameters to existing chain file
+    ! 
+    ! Arguments:
+    ! ----------
+    ! self:     derived class (comm_WMAP_tod)
+    !           WMAP-specific TOD object
+    ! chainfile: derived type (hdf_file)
+    !           Already open HDF file handle to existing chainfile
+    ! path:   string
+    !           HDF path to current dataset, e.g., "000001/tod/030"
+    !
+    ! Returns
+    ! ----------
+    ! None
+    !
+    implicit none
+    class(comm_WMAP_tod),                intent(in)     :: self
+    type(hdf_file),                      intent(in)     :: chainfile
+    character(len=*),                    intent(in)     :: path
+  end subroutine dumpToHDF_WMAP
 
 
 end module comm_tod_WMAP_mod

--- a/commander3/src/comm_tod_mod.f90
+++ b/commander3/src/comm_tod_mod.f90
@@ -32,7 +32,7 @@ module comm_tod_mod
   implicit none
 
   private
-  public comm_tod, initialize_tod_mod, fill_masked_region, fill_all_masked, tod_pointer, byte_pointer
+  public comm_tod, comm_scan, initialize_tod_mod, fill_masked_region, fill_all_masked, tod_pointer, byte_pointer
 
   type :: byte_pointer
    byte, dimension(:), allocatable :: p 
@@ -156,26 +156,28 @@ module comm_tod_mod
      integer(i4b)                                      :: verbosity ! verbosity of output
      integer(i4b),       allocatable, dimension(:,:)   :: jumplist  ! List of stationary periods (ndet,njump+2)
    contains
-     procedure                        :: read_tod
-     procedure                        :: get_scan_ids
-     procedure                        :: dumpToHDF
-     procedure                        :: initHDF
-     procedure                        :: get_det_id
-     procedure                        :: initialize_bp_covar
-     procedure(process_tod), deferred :: process_tod
-     procedure                        :: construct_sl_template
-     procedure                        :: construct_dipole_template
-     procedure                        :: output_scan_list
-     procedure                        :: downsample_tod
-     procedure                        :: compute_chisq
-     procedure                        :: get_total_chisq
-     procedure                        :: symmetrize_flags
-     procedure                        :: decompress_pointing_and_flags
-     procedure                        :: decompress_tod
-     procedure                        :: tod_constructor
-     procedure                        :: load_instrument_file
-     procedure                        :: precompute_lookups
-     procedure                        :: read_jumplist
+     procedure                           :: read_tod
+     procedure(read_tod_inst), deferred  :: read_tod_inst
+     procedure(read_scan_inst), deferred :: read_scan_inst
+     procedure                           :: get_scan_ids
+     procedure                           :: dumpToHDF
+     procedure                           :: initHDF
+     procedure                           :: get_det_id
+     procedure                           :: initialize_bp_covar
+     procedure(process_tod), deferred    :: process_tod
+     procedure                           :: construct_sl_template
+     procedure                           :: construct_dipole_template
+     procedure                           :: output_scan_list
+     procedure                           :: downsample_tod
+     procedure                           :: compute_chisq
+     procedure                           :: get_total_chisq
+     procedure                           :: symmetrize_flags
+     procedure                           :: decompress_pointing_and_flags
+     procedure                           :: decompress_tod
+     procedure                           :: tod_constructor
+     procedure                           :: load_instrument_file
+     procedure                           :: precompute_lookups
+     procedure                           :: read_jumplist
   end type comm_tod
 
   abstract interface
@@ -191,6 +193,23 @@ module comm_tod_mod
        class(comm_map),                     intent(inout) :: map_out
        class(comm_map),                     intent(inout) :: rms_out
      end subroutine process_tod
+
+     subroutine read_tod_inst(self, file)
+       import comm_tod, hdf_file
+       implicit none
+       class(comm_tod),                     intent(inout)          :: self
+       type(hdf_file),                      intent(in),   optional :: file
+     end subroutine read_tod_inst
+
+     subroutine read_scan_inst(self, file, slabel, detlabels, scan)
+       import comm_tod, hdf_file, comm_scan
+       implicit none
+       class(comm_tod),                     intent(in)    :: self
+       type(hdf_file),                      intent(in)    :: file
+       character(len=*),                    intent(in)    :: slabel
+       character(len=*), dimension(:),      intent(in)    :: detlabels
+       class(comm_scan),                    intent(inout) :: scan
+     end subroutine read_scan_inst
   end interface
 
   type tod_pointer
@@ -211,8 +230,29 @@ contains
     if (cpar%include_tod_zodi) call initialize_zodi_mod(cpar)
   end subroutine initialize_tod_mod
 
-  !common constructor functionality for all tod processing classes
   subroutine tod_constructor(self, cpar, id_abs, info, tod_type)
+    ! 
+    ! Common constructor function for all TOD objects; allocatates and initializes general
+    ! data structures. This routine is typically called from within an instrument-specific 
+    ! initialization routine, *after* defining fields such that nhorn, ndet etc.
+    ! 
+    ! Arguments:
+    ! ----------
+    ! self:     derived class (comm_tod)
+    !           TOD object to be initialized
+    ! cpar:     derived type
+    !           Object containing parameters from the parameterfile.
+    ! id_abs:   integer
+    !           The index of the current band within the parameters, related to cpar
+    ! info:     map_info structure
+    !           Information about the maps for this band, like how the maps are distributed in memory
+    ! tod_type: string
+    !           Instrument specific tod type
+    !
+    ! Returns
+    ! ----------
+    ! None, but updates self
+    !
     implicit none
     class(comm_tod),                intent(inout)  :: self
     integer(i4b),                   intent(in)     :: id_abs
@@ -317,6 +357,17 @@ contains
   end subroutine tod_constructor
 
   subroutine precompute_lookups(self)
+    ! 
+    ! Routine that precomputes static look-up tables in a given TOD object (pix2ind, ind2pix, ind2sl, ind2ang). 
+    ! 
+    ! Arguments:
+    ! ----------
+    ! self:     derived class (comm_tod)
+    !           TOD object to be initialized
+    ! Returns
+    ! ----------
+    ! None, but updates self
+    !
     implicit none
     class(comm_tod),                intent(inout)  :: self
 
@@ -429,6 +480,19 @@ contains
 
 
   subroutine read_tod(self, detlabels)
+    ! 
+    ! Reads common TOD fields into existing TOD object
+    ! 
+    ! Arguments:
+    ! ----------
+    ! self:     derived class (comm_tod)
+    !           TOD object to be initialized
+    ! detlabels: string (array)
+    !           Array of detector labels, e.g., ["27M", "27S"]
+    ! Returns
+    ! ----------
+    ! None, but updates self
+    !
     implicit none
     class(comm_tod),                intent(inout)  :: self
     character(len=*), dimension(:), intent(in)     :: detlabels
@@ -449,7 +513,6 @@ contains
     self%mono = 0.d0
     if (self%myid == 0) then
        call open_hdf_file(self%initfile, file, "r")
-
 
        !TODO: figure out how to make this work
        call read_hdf_string2(file, "/common/det",    det_buf, n)
@@ -495,7 +558,13 @@ contains
           self%mbang(i) = mbang_buf(j)
        end do
        deallocate(polang_buf, mbang_buf, dets)
+
+       ! Read instrument specific parameters
+       call self%read_tod_inst(file)
+
        call close_hdf_file(file)
+    else
+       call self%read_tod_inst
     end if
     call mpi_bcast(self%nside,    1,     MPI_INTEGER,          0, self%comm, ierr)
     call mpi_bcast(self%npsi,     1,     MPI_INTEGER,          0, self%comm, ierr)
@@ -569,6 +638,36 @@ contains
   end subroutine read_tod
 
   subroutine read_hdf_scan(self, tod, filename, scan, ndet, detlabels, nhorn)
+    ! 
+    ! Reads common scan information from TOD fileset
+    ! 
+    ! Arguments:
+    ! ----------
+    ! self:     derived class (comm_scan)
+    !           Scan object
+    ! tod:      derived class (comm_tod)
+    !           Main TOD object to which current scan belongs
+    ! filename: character
+    !           TOD filename
+    ! scan:     int
+    !           Scan ID
+    ! ndet:     int
+    !           Number of detectors
+    ! nhorn:    int
+    !           Number of horns
+    ! detlabels: string (array)
+    !           Array of detector labels, e.g., ["27M", "27S"]
+    ! scan:     derived class (comm_scan)
+    !           
+    !
+    ! Returns
+    ! ----------
+    ! None, but updates scan object
+    !
+    ! TODO
+    ! ----
+    ! - ndet, nhorn and detlabels should be taken from tod, not inserted as separate parameters?
+    ! 
     implicit none
     class(comm_scan),               intent(inout) :: self
     class(comm_tod),                intent(in)    :: tod
@@ -704,6 +803,10 @@ contains
     call wall_time(t2)
     t_tot(6) = t_tot(6) + t2-t1
 
+    ! Read instrument-specific infomation
+    call tod%read_scan_inst(file, slabel, detlabels, self)
+
+    ! Clean up
     call close_hdf_file(file)
 
     call wall_time(t4)


### PR DESCRIPTION
This commit adds support for instrument-specific IO routines. Now all instrument TOD modules *must* define four new routines:

read_tod_inst -> Read common parameters
read_scan_inst -> Read scan-specific parameters
initHDF_inst -> Initialize from chainfile
dumpToHDF_inst -> Write to chainfile

These may be empty, however.