### PR TITLE
New noise PSD model

### DIFF
--- a/cmake/commander3.cmake
+++ b/cmake/commander3.cmake
@@ -78,6 +78,7 @@ set(sources
   ${COMMANDER3_SOURCE_DIR}/comm_tod_SPIDER_mod.f90
   ${COMMANDER3_SOURCE_DIR}/comm_tod_LB_mod.f90
   ${COMMANDER3_SOURCE_DIR}/comm_tod_jump_mod.f90
+  ${COMMANDER3_SOURCE_DIR}/comm_tod_driver_mod.f90
 	# TOD simulations module (and submodules)
 	${COMMANDER3_SOURCE_DIR}/comm_tod_simulations_mod.f90
 	#

--- a/cmake/commander3.cmake
+++ b/cmake/commander3.cmake
@@ -67,6 +67,7 @@ set(sources
 	${COMMANDER3_SOURCE_DIR}/comm_F_int_0D_mod.f90
 	${COMMANDER3_SOURCE_DIR}/comm_N_rms_mod.f90
 	# TOD processing modules
+	${COMMANDER3_SOURCE_DIR}/comm_tod_noise_psd_mod.f90
 	${COMMANDER3_SOURCE_DIR}/comm_tod_mod.f90
 	${COMMANDER3_SOURCE_DIR}/comm_tod_mapmaking_mod.f90
 	${COMMANDER3_SOURCE_DIR}/comm_tod_LFI_mod.f90

--- a/commander3/src/Makefile
+++ b/commander3/src/Makefile
@@ -31,7 +31,8 @@ COBJS  := d1mach.o drc3jj.o hashtbl.o hashtbl_4Dmap.o powell_mod.o comm_hdf_mod.
 	  comm_gain_mod.o comm_nonlin_mod.o comm_N_mod.o comm_N_rms_mod.o comm_N_QUcov_mod.o \
           comm_B_mod.o comm_B_bl_mod.o comm_beam_mod.o \
           comm_F_int_mod.o comm_F_int_1D_mod.o comm_F_int_0D_mod.o comm_F_int_2D_mod.o \
-          comm_fft_mod.o comm_tod_mod.o comm_tod_mapmaking_mod.o comm_tod_bandpass_mod.o comm_tod_gain_mod.o comm_tod_pointing_mod.o comm_tod_LFI_mod.o comm_tod_jump_mod.o comm_tod_SPIDER_mod.o comm_tod_orbdipole_mod.o \
+          comm_fft_mod.o comm_tod_noise_psd_mod.o comm_tod_mod.o comm_tod_mapmaking_mod.o comm_tod_bandpass_mod.o \
+          comm_tod_gain_mod.o comm_tod_pointing_mod.o comm_tod_LFI_mod.o comm_tod_jump_mod.o comm_tod_SPIDER_mod.o comm_tod_orbdipole_mod.o \
           comm_tod_noise_mod.o comm_tod_driver_mod.o comm_F_line_mod.o comm_data_mod.o comm_bp_mod.o comm_Cl_mod.o \
           comm_chisq_mod.o comm_cr_mod.o comm_signal_mod.o comm_output_mod.o comm_tod_WMAP_mod.o \
 					comm_tod_simulations_mod.o comm_tod_LB_mod.o
@@ -46,7 +47,8 @@ comm_map_mod.o :           sharp.o comm_hdf_mod.o comm_param_mod.o
 comm_conviqt_mod.o :       sharp.o comm_map_mod.o comm_shared_arr_mod.o
 comm_hdf_mod.o :           comm_utils.o
 comm_fft_mod.o :           locate_mod.o comm_utils.o comm_param_mod.o
-comm_tod_mod.o :           comm_utils.o comm_fft_mod.o comm_map_mod.o comm_hdf_mod.o comm_param_mod.o \
+comm_tod_noise_psd_mod.o : comm_utils.o
+comm_tod_mod.o :           comm_tod_noise_psd_mod.o comm_fft_mod.o comm_map_mod.o comm_hdf_mod.o comm_param_mod.o \
 			   comm_huffman_mod.o comm_zodi_mod.o comm_tod_orbdipole_mod.o
 comm_tod_mapmaking_mod.o:  comm_tod_mod.o
 comm_tod_bandpass_mod.o:   comm_tod_mod.o

--- a/commander3/src/comm_tod_LB_mod.f90
+++ b/commander3/src/comm_tod_LB_mod.f90
@@ -100,8 +100,11 @@ contains
     integer(i4b) :: i, nside_beam, lmax_beam, nmaps_beam, ierr
     logical(lgt) :: pol_beam
 
-    ! Initialize common parameters
+    ! Allocate object
     allocate(constructor)
+    constructor%noise_psd_model = 'oof'
+
+    ! Initialize common parameters
     call constructor%tod_constructor(cpar, id_abs, info, tod_type)
 
     ! Initialize instrument-specific parameters
@@ -345,16 +348,16 @@ contains
        call compute_calibrated_data(self, i, sd, d_calib)    
 
        ! Output 4D map; note that psi is zero-base in 4D maps, and one-base in Commander
-       if (self%output_4D_map > 0) then
-          if (mod(iter-1,self%output_4D_map) == 0) then
-             call output_4D_maps_hdf(trim(chaindir) // '/tod_4D_chain'//ctext//'_proc' // myid_text // '.h5', &
-                  & samptext, self%scanid(i), self%nside, self%npsi, &
-                  & self%label, self%horn_id, real(self%polang*180/pi,sp), &
-                  & real(self%scans(i)%d%sigma0/self%scans(i)%d%gain,sp), &
-                  & sd%pix(:,:,1), sd%psi(:,:,1)-1, d_calib(1,:,:), iand(sd%flag,self%flag0), &
-                  & self%scans(i)%d(:)%accept)
-          end if
-       end if
+!!$       if (self%output_4D_map > 0) then
+!!$          if (mod(iter-1,self%output_4D_map) == 0) then
+!!$             call output_4D_maps_hdf(trim(chaindir) // '/tod_4D_chain'//ctext//'_proc' // myid_text // '.h5', &
+!!$                  & samptext, self%scanid(i), self%nside, self%npsi, &
+!!$                  & self%label, self%horn_id, real(self%polang*180/pi,sp), &
+!!$                  & real(self%scans(i)%d%sigma0/self%scans(i)%d%gain,sp), &
+!!$                  & sd%pix(:,:,1), sd%psi(:,:,1)-1, d_calib(1,:,:), iand(sd%flag,self%flag0), &
+!!$                  & self%scans(i)%d(:)%accept)
+!!$          end if
+!!$       end if
 
        ! Bin TOD
        call bin_TOD(self, i, sd%pix(:,:,1), sd%psi(:,:,1), sd%flag, d_calib, binmap)

--- a/commander3/src/comm_tod_SPIDER_mod.f90
+++ b/commander3/src/comm_tod_SPIDER_mod.f90
@@ -617,12 +617,12 @@ contains
           if (main_iter == 1 .and. self%first_call) then
              do j = 1, ndet
                 if (all(mask(:,j) == 0)) self%scans(i)%d(j)%accept = .false.
-                if (self%scans(i)%d(j)%sigma0 <= 0.d0) self%scans(i)%d(j)%accept = .false.
+                if (self%scans(i)%d(j)%N_psd%sigma0 <= 0.d0) self%scans(i)%d(j)%accept = .false.
              end do
           end if
           do j = 1, ndet
              if (.not. self%scans(i)%d(j)%accept) cycle
-             if (self%scans(i)%d(j)%sigma0 <= 0) write(*,*) main_iter, self%scanid(i), j, self%scans(i)%d(j)%sigma0
+             if (self%scans(i)%d(j)%N_psd%sigma0 <= 0) write(*,*) main_iter, self%scanid(i), j, self%scans(i)%d(j)%N_psd%sigma0
           end do
           call wall_time(t2); t_tot(1) = t_tot(1) + t2-t1
           !call update_status(status, "tod_project")
@@ -861,7 +861,7 @@ contains
                 if (.not. self%scans(i)%d(j)%accept) cycle
                 if (do_oper(samp_G) .or. do_oper(samp_rcal) .or. .not. self%orb_abscal) then
                    s_buf(:,j) = s_tot(:,j)
-                   call fill_all_masked(s_buf(:,j), mask(:,j), ntod, trim(self%operation)=='sample', real(self%scans(i)%d(j)%sigma0, sp), handle, self%scans(i)%chunk_num)
+                   call fill_all_masked(s_buf(:,j), mask(:,j), ntod, trim(self%operation)=='sample', real(self%scans(i)%d(j)%N_psd%sigma0, sp), handle, self%scans(i)%chunk_num)
                    call self%downsample_tod(s_buf(:,j), ext, &
                         & s_lowres(:,j))!, mask(:,j))
                 else
@@ -918,7 +918,7 @@ contains
           !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!! Harald
           if (self%first_call) then
             do j = 1, ndet
-               self%scans(i)%d(j)%sigma0 = 0.0018
+               self%scans(i)%d(j)%N_psd%sigma0 = 0.0018
             end do
           end if
           !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
@@ -1128,13 +1128,13 @@ contains
              if (do_oper(bin_map) .and. self%output_4D_map > 0 .and. mod(iter,self%output_4D_map) == 0) then
 
                 ! Output 4D map; note that psi is zero-base in 4D maps, and one-base in Commander
-                call int2string(self%scanid(i), scantext)
-                prefix4D = "!"//trim(prefix) // '4D_pid' // scantext
-                call output_4D_maps(prefix4D, postfix, self%scanid(i), self%nside, self%npsi, &
-                     & self%label, self%horn_id, real(self%polang*180/pi,sp), &
-                     & real(self%scans(i)%d%sigma0/self%scans(i)%d%gain,sp), &
-                     & pix(:,:,1), psi(:,:,1)-1, d_calib(1,:,:), iand(flag,self%flag0), &
-                     & self%scans(i)%d(:)%accept)
+!!$                call int2string(self%scanid(i), scantext)
+!!$                prefix4D = "!"//trim(prefix) // '4D_pid' // scantext
+!!$                call output_4D_maps(prefix4D, postfix, self%scanid(i), self%nside, self%npsi, &
+!!$                     & self%label, self%horn_id, real(self%polang*180/pi,sp), &
+!!$                     & real(self%scans(i)%d%N_psdsigma0/self%scans(i)%d%gain,sp), &
+!!$                     & pix(:,:,1), psi(:,:,1)-1, d_calib(1,:,:), iand(flag,self%flag0), &
+!!$                     & self%scans(i)%d(:)%accept)
              end if
 
 

--- a/commander3/src/comm_tod_WMAP_mod.f90
+++ b/commander3/src/comm_tod_WMAP_mod.f90
@@ -460,7 +460,7 @@ contains
             if (main_iter == 1 .and. self%first_call) then
                do j = 1, ndet
                   if (all(mask(:,j) == 0)) self%scans(i)%d(j)%accept = .false.
-                  if (self%scans(i)%d(j)%sigma0 <= 0.d0) self%scans(i)%d(:)%accept = .false.
+                  if (self%scans(i)%d(j)%N_psd%sigma0 <= 0.d0) self%scans(i)%d(:)%accept = .false.
                end do
             end if
             call wall_time(t2); t_tot(1) = t_tot(1) + t2-t1
@@ -540,7 +540,7 @@ contains
               &- self%scans(i)%d(j)%gain*s_tot(:,j))*mask(:,j))/sum(mask(:,j))
                 if (trim(self%operation) == 'sample') then
                   self%scans(i)%d(j)%baseline = self%scans(i)%d(j)%baseline &
-                   &  + rand_gauss(handle)/sqrt(sum(mask(:,j)*self%scans(i)%d(j)%sigma0**2))
+                   &  + rand_gauss(handle)/sqrt(sum(mask(:,j)*self%scans(i)%d(j)%N_psd%sigma0**2))
                 end if
               end if
             end do
@@ -563,7 +563,7 @@ contains
                      s_buf(:,j) = s_tot(:,j)
                      call fill_all_masked(s_buf(:,j), mask(:,j), ntod, &
                      &  .false., &   !trim(self%operation)=='sample', &
-                     &  real(self%scans(i)%d(j)%sigma0, sp), &
+                     &  real(self%scans(i)%d(j)%N_psd%sigma0, sp), &
                      &  handle, self%scans(i)%chunk_num)
                      call self%downsample_tod(s_buf(:,j), ext, &
                           & s_invN(:,j))!, mask(:,j))
@@ -593,7 +593,7 @@ contains
                    s_buf(:,j) = self%scans(i)%d(j)%gain*(s_totA(:,j)+s_totB(:,j))
                    call fill_all_masked(s_buf(:,j), mask(:,j), ntod, &
                    &  .false., &   !trim(self%operation)=='sample', &
-                   &  real(self%scans(i)%d(j)%sigma0, sp), &
+                   &  real(self%scans(i)%d(j)%N_psd%sigma0, sp), &
                    &  handle, self%scans(i)%chunk_num)
                    call self%downsample_tod(s_buf(:,j), ext, &
                         & s_invN(:,j))!, mask(:,j))
@@ -1183,7 +1183,7 @@ contains
           cycle
        end if
        r_fill = tod_arr(:,j) - s_sub(:,j) - tod%scans(scan)%d(j)%baseline
-       call fill_all_masked(r_fill, mask(:,j), ntod, trim(tod%operation) == 'sample', abs(real(tod%scans(scan)%d(j)%sigma0, sp)), handle, tod%scans(scan)%chunk_num)
+       call fill_all_masked(r_fill, mask(:,j), ntod, trim(tod%operation) == 'sample', abs(real(tod%scans(scan)%d(j)%N_psd%sigma0, sp)), handle, tod%scans(scan)%chunk_num)
        call tod%downsample_tod(r_fill, ext, residual(:,j))
     end do
 

--- a/commander3/src/comm_tod_driver_mod.f90
+++ b/commander3/src/comm_tod_driver_mod.f90
@@ -158,7 +158,7 @@ contains
     do j = 1, self%ndet
        if (.not. tod%scans(scan)%d(j)%accept) cycle
        if (all(self%mask(:,j) == 0)) tod%scans(scan)%d(j)%accept = .false.
-       if (tod%scans(scan)%d(j)%sigma0 <= 0.d0) tod%scans(scan)%d(j)%accept = .false.
+       if (tod%scans(scan)%d(j)%N_psd%sigma0 <= 0.d0) tod%scans(scan)%d(j)%accept = .false.
     end do
     !if (.true. .or. tod%myid == 78) write(*,*) 'c8', tod%myid, tod%correct_sl, tod%ndet, tod%slconv(1)%p%psires
     
@@ -327,7 +327,7 @@ contains
     do j = 1, self%ndet
        if (.not. tod%scans(scan)%d(j)%accept) cycle
        if (all(self%mask(:,j) == 0)) tod%scans(scan)%d(j)%accept = .false.
-       if (tod%scans(scan)%d(j)%sigma0 <= 0.d0) tod%scans(scan)%d(j)%accept = .false.
+       if (tod%scans(scan)%d(j)%N_psd%sigma0 <= 0.d0) tod%scans(scan)%d(j)%accept = .false.
     end do
     
     ! Construct orbital dipole template
@@ -470,7 +470,7 @@ contains
           else
              ! Calibratior = total signal
              s_buf(:,j) = sd%s_tot(:,j)
-             call fill_all_masked(s_buf(:,j), sd%mask(:,j), sd%ntod, .false., real(tod%scans(i)%d(j)%sigma0, sp), handle, tod%scans(i)%chunk_num)
+             call fill_all_masked(s_buf(:,j), sd%mask(:,j), sd%ntod, .false., real(tod%scans(i)%d(j)%N_psd%sigma0, sp), handle, tod%scans(i)%chunk_num)
              call tod%downsample_tod(s_buf(:,j), ext, s_invN(:,j))
           end if
        end do
@@ -724,11 +724,11 @@ contains
       ! getting gain for each detector (units, V / K)
       ! (gain is assumed to be CONSTANT for EACH SCAN)
       gain   = self%scans(scan_id)%d(j)%gain
-      sigma0 = self%scans(scan_id)%d(j)%sigma0
+      sigma0 = self%scans(scan_id)%d(j)%N_psd%sigma0
       samprate = self%samprate
-      alpha    = self%scans(scan_id)%d(j)%alpha
+      alpha    = self%scans(scan_id)%d(j)%N_psd%alpha
       ! knee frequency
-      nu_knee  = self%scans(scan_id)%d(j)%fknee
+      nu_knee  = self%scans(scan_id)%d(j)%N_psd%fknee
       ! used when adding fluctuation terms to Fourier coeffs (depends on Fourier convention)
       fft_norm = sqrt(1.d0 * nfft)
       !
@@ -763,7 +763,7 @@ contains
         ! (gain is assumed to be CONSTANT for EACH SCAN)
         gain   = self%scans(scan_id)%d(j)%gain
         !write(*,*) "gain ", gain
-        sigma0 = self%scans(scan_id)%d(j)%sigma0
+        sigma0 = self%scans(scan_id)%d(j)%N_psd%sigma0
         !write(*,*) "sigma0 ", sigma0
         ! Simulating tods
         tod_per_detector(i,j) = gain * s_tot(i,j) + n_corr(i, j) + sigma0 * rand_gauss(handle)

--- a/commander3/src/comm_tod_gain_mod.f90
+++ b/commander3/src/comm_tod_gain_mod.f90
@@ -71,7 +71,7 @@ contains
          r_fill = tod%scans(scan_id)%d(j)%tod - tod%scans(scan_id)%d(j)%baseline & 
            & - (tod%gain0(0) + tod%gain0(j)) * s_tot(:,j)
        end if
-       call fill_all_masked(r_fill, mask(:,j), ntod, trim(tod%operation) == 'sample', real(tod%scans(scan_id)%d(j)%sigma0, sp), handle, tod%scans(scan_id)%chunk_num)
+       call fill_all_masked(r_fill, mask(:,j), ntod, trim(tod%operation) == 'sample', real(tod%scans(scan_id)%d(j)%N_psd%sigma0, sp), handle, tod%scans(scan_id)%chunk_num)
        call tod%downsample_tod(r_fill, ext, residual(:,j))
     end do
     call multiply_inv_N(tod, scan_id, residual, sampfreq=tod%samprate_lowres, pow=0.5d0)
@@ -489,7 +489,7 @@ contains
          r_fill = tod%scans(scan)%d(j)%tod - s_sub(:,j) - tod%scans(scan)%d(j)%baseline
          !if (tod%scanid(scan) == 1348 .and. out) write(*,*) tod%scanid(scan), sum(abs(tod%scans(scan)%d(j)%tod)), sum(abs(s_sub(:,j))), tod%scans(scan)%d(j)%baseline
        end if
-       call fill_all_masked(r_fill, mask(:,j), ntod, trim(tod%operation) == 'sample', abs(real(tod%scans(scan)%d(j)%sigma0, sp)), handle, tod%scans(scan)%chunk_num)
+       call fill_all_masked(r_fill, mask(:,j), ntod, trim(tod%operation) == 'sample', abs(real(tod%scans(scan)%d(j)%N_psd%sigma0, sp)), handle, tod%scans(scan)%chunk_num)
        call tod%downsample_tod(r_fill, ext, residual(:,j))
     end do
 

--- a/commander3/src/comm_tod_mapmaking_mod.f90
+++ b/commander3/src/comm_tod_mapmaking_mod.f90
@@ -162,7 +162,7 @@ contains
     do det = 1, size(pix,2)
        if (.not. tod%scans(scan)%d(det)%accept) cycle
        off         = 6 + 4*(det-1)
-       inv_sigmasq = (tod%scans(scan)%d(det)%gain/tod%scans(scan)%d(det)%sigma0)**2
+       inv_sigmasq = (tod%scans(scan)%d(det)%gain/tod%scans(scan)%d(det)%N_psd%sigma0)**2
        do t = 1, size(pix,1)
           
           if (iand(flag(t,det),tod%flag0) .ne. 0) cycle
@@ -229,7 +229,7 @@ contains
          !inv_sigmasq = 0.d0 
          var = 0
          do det = 1, 4
-           var = var  + (tod%scans(scan)%d(det)%sigma0/tod%scans(scan)%d(det)%gain)**2/4
+           var = var  + (tod%scans(scan)%d(det)%N_psd%sigma0/tod%scans(scan)%d(det)%gain)**2/4
            !inv_sigmasq = inv_sigmasq  + (tod%scans(scan)%d(det)%gain/tod%scans(scan)%d(det)%sigma0)**2
          end do
          inv_sigmasq = 1/var
@@ -329,7 +329,7 @@ end subroutine bin_differential_TOD
             !inv_sigmasq = 0.d0 
             var = 0
             do k = 1, 4
-               var = var + (tod%scans(j)%d(k)%sigma0/tod%scans(j)%d(k)%gain)**2/4
+               var = var + (tod%scans(j)%d(k)%N_psd%sigma0/tod%scans(j)%d(k)%gain)**2/4
                !inv_sigmasq = inv_sigmasq  + (tod%scans(j)%d(k)%gain/tod%scans(j)%d(k)%sigma0)**2
             end do
             inv_sigmasq = 1.d0/var

--- a/commander3/src/comm_tod_mod.f90
+++ b/commander3/src/comm_tod_mod.f90
@@ -28,6 +28,7 @@ module comm_tod_mod
   use comm_conviqt_mod
   use comm_zodi_mod
   use comm_tod_orbdipole_mod
+  use comm_tod_noise_psd_mod
   USE ISO_C_BINDING
   implicit none
 
@@ -38,28 +39,25 @@ module comm_tod_mod
    byte, dimension(:), allocatable :: p 
   end type byte_pointer
 
-
   type :: comm_detscan
      character(len=10) :: label                             ! Detector label
-     real(dp)          :: gain, dgain, gain_invsigma           ! Gain; assumed constant over scan
-     real(dp)          :: sigma0, alpha, fknee              ! Noise parameters
-     real(dp)          :: gain_def, sigma0_def, alpha_def, fknee_def ! Default parameters
+     real(dp)          :: gain, dgain, gain_invsigma        ! Gain; assumed constant over scan
+     real(dp)          :: gain_def                          ! Default parameters
      real(dp)          :: chisq
      real(dp)          :: chisq_prop
      real(dp)          :: chisq_masked
      real(sp)          :: baseline
      logical(lgt)      :: accept
-     real(sp),     allocatable, dimension(:)  :: tod        ! Detector values in time domain, (ntod)
-     byte,     allocatable, dimension(:)  :: ztod        ! compressed values in time domain, (ntod)
-     byte,         allocatable, dimension(:)  :: flag       ! Compressed detector flag; 0 is accepted, /= 0 is rejected
-     type(byte_pointer), allocatable, dimension(:)  :: pix   ! pointer array of pixels length nhorn
-     type(byte_pointer), allocatable, dimension(:)  :: psi   ! pointer array of psi, length nhorn
-     real(dp),     allocatable, dimension(:)  :: log_n_psd  ! Noise power spectrum density; in uncalibrated units
-     real(dp),     allocatable, dimension(:)  :: log_n_psd2 ! Second derivative (for spline)
-     real(dp),     allocatable, dimension(:)  :: log_nu     ! Noise power spectrum bins; in Hz
-     integer(i4b), allocatable, dimension(:,:)  :: offset_range    ! Beginning and end tod index of every offset region
-     real(sp),     allocatable, dimension(:)    :: offset_level    ! Amplitude of every offset region(step)
-     integer(i4b), allocatable, dimension(:,:)  :: jumpflag_range  ! Beginning and end tod index of regions where jumps occur
+     class(comm_noise_psd), pointer :: N_psd                            ! Noise PSD object
+     real(sp),           allocatable, dimension(:)    :: tod            ! Detector values in time domain, (ntod)
+     byte,               allocatable, dimension(:)    :: ztod           ! compressed values in time domain, (ntod)
+     byte,               allocatable, dimension(:)    :: flag           ! Compressed detector flag; 0 is accepted, /= 0 is rejected
+     type(byte_pointer), allocatable, dimension(:)    :: pix            ! pointer array of pixels length nhorn
+     type(byte_pointer), allocatable, dimension(:)    :: psi            ! pointer array of psi, length nhorn
+     real(sp),           allocatable, dimension(:)    :: xi_n           ! Noise PSD parameters
+     integer(i4b),       allocatable, dimension(:,:)  :: offset_range   ! Beginning and end tod index of every offset region
+     real(sp),           allocatable, dimension(:)    :: offset_level   ! Amplitude of every offset region(step)
+     integer(i4b),       allocatable, dimension(:,:)  :: jumpflag_range ! Beginning and end tod index of regions where jumps occur
   end type comm_detscan
 
   type :: comm_scan
@@ -85,7 +83,8 @@ module comm_tod_mod
      character(len=512) :: instfile
      character(len=512) :: operation
      character(len=512) :: outdir
-     character(len=512) :: sims_output_dir !< simulation folder
+     character(len=512) :: sims_output_dir  !< simulation folder
+     character(len=512) :: noise_psd_model  
      logical(lgt) :: enable_tod_simulations !< simulation parameter to run commander3 in different regime
      logical(lgt) :: first_call
      integer(i4b) :: comm, myid, numprocs                         ! MPI parameters
@@ -98,6 +97,7 @@ module comm_tod_mod
      integer(i4b) :: first_scan, last_scan
      integer(i4b) :: npsi                                         ! Number of discretized psi steps
      integer(i4b) :: flag0
+     integer(i4b) :: n_xi                                         ! Number of noise parameters
 
      real(dp)     :: central_freq                                 !Central frequency
      real(dp)     :: samprate, samprate_lowres                    ! Sample rate in Hz
@@ -309,6 +309,15 @@ contains
     self%verbosity     = cpar%verbosity
     self%sims_output_dir = cpar%sims_output_dir
     self%enable_tod_simulations = cpar%enable_tod_simulations
+
+    if (trim(self%noise_psd_model) == 'oof') then
+       self%n_xi = 3  ! {sigma0, alpha, fknee}
+    else if (trim(self%noise_psd_model) == '2oof') then
+       self%n_xi = 5  ! {sigma0, alpha, fknee, alpha2, fknee2}
+    else
+       write(*,*) 'Error: Invalid noise PSD model = ', trim(self%noise_psd_model)
+       stop
+    end if
 
     call mpi_comm_size(cpar%comm_shared, self%numprocs_shared, ierr)
 
@@ -694,19 +703,13 @@ contains
     character(len=*), dimension(:), intent(in)     :: detlabels
 
     integer(i4b)       :: i,j, n, m, ext(1)
-    real(dp)           :: t1, t2, t3, t4, t_tot(6), scalars(4)
+    real(dp)           :: scalars(4)
     character(len=6)   :: slabel
     character(len=128) :: field
     type(hdf_file)     :: file
     integer(i4b), allocatable, dimension(:)       :: hsymb
     real(sp),     allocatable, dimension(:)       :: buffer_sp
     integer(i4b), allocatable, dimension(:)       :: htree
-
-
-    call wall_time(t3)
-    t_tot = 0.d0
-
-    call wall_time(t1)
 
     self%chunk_num = scan
     call int2string(scan, slabel)
@@ -743,41 +746,29 @@ contains
     call read_hdf(file, slabel // "/common/time",  self%t0)
     ! HKE: LFI files should be regenerated with (x,y,z) info
     !call read_hdf(file, slabel // "/common/satpos",  self%satpos, opt=.true.)
-    call wall_time(t2)
-    t_tot(1) = t2-t1
-
-    !write(*,*) self%t0(1), real(self%v_sun), "# v"
 
     ! Read detector scans
     allocate(self%d(ndet), buffer_sp(n))
     do i = 1, ndet
        allocate(self%d(i)%psi(nhorn), self%d(i)%pix(nhorn))
+       allocate(self%d(i)%xi_n(tod%n_xi))
 
-       call wall_time(t1)
        field = detlabels(i)
-       call wall_time(t2)
-       t_tot(2) = t_tot(2) + t2-t1
-       call wall_time(t1)
        self%d(i)%label = trim(field)
        call read_hdf(file, slabel // "/" // trim(field) // "/scalars",   scalars)
        self%d(i)%gain_def   = scalars(1)
-       self%d(i)%sigma0_def = scalars(2) * self%d(i)%gain_def  ! To get sigma0 in uncalibrated units
-       self%d(i)%fknee_def  = scalars(3)
-       self%d(i)%alpha_def  = scalars(4)
-       self%d(i)%gain       = self%d(i)%gain_def
-       self%d(i)%sigma0     = self%d(i)%sigma0_def
-       self%d(i)%fknee      = self%d(i)%fknee_def
-       self%d(i)%alpha      = self%d(i)%alpha_def
+       self%d(i)%xi_n(1:3)  = scalars(2:4)
+       self%d(i)%xi_n(1)    = self%d(i)%xi_n(1) * self%d(i)%gain_def ! Convert sigma0 to uncalibrated units
 
-       call wall_time(t2)
-       t_tot(3) = t_tot(3) + t2-t1
-       call wall_time(t1)
-       call wall_time(t2)
-       t_tot(4) = t_tot(4) + t2-t1
-
+       if (trim(tod%noise_psd_model) == 'oof') then
+          self%d(i)%N_psd => comm_noise_psd(self%d(i)%xi_n, self%d(i)%xi_n)
+       else if (trim(tod%noise_psd_model) == '2oof') then
+          self%d(i)%xi_n(4) = -1.000 ! alpha2; arbitrary value
+          self%d(i)%xi_n(5) =  1e-4  ! fknee2 (Hz); arbitrary value
+          self%d(i)%N_psd => comm_noise_psd_2oof(self%d(i)%xi_n, self%d(i)%xi_n)
+       end if
 
        ! Read Huffman coded data arrays
-       call wall_time(t1)
        if (nhorn == 2) then
          do j = 1, nhorn 
            call read_hdf_opaque(file, slabel // "/" // trim(field) // "/pix" // char(j+64),  self%d(i)%pix(j)%p)
@@ -802,13 +793,10 @@ contains
              self%d(i)%tod = buffer_sp(1:m)
           end if
        end if
-       call wall_time(t2)
-       t_tot(5) = t_tot(5) + t2-t1
     end do
     deallocate(buffer_sp)
 
     ! Initialize Huffman key
-    call wall_time(t1)
     call read_alloc_hdf(file, slabel // "/common/huffsymb", hsymb)
     call read_alloc_hdf(file, slabel // "/common/hufftree", htree)
     call hufmak_precomp(hsymb,htree,self%hkey)
@@ -818,27 +806,12 @@ contains
        call hufmak_precomp(hsymb,htree,self%todkey)
     end if
     deallocate(hsymb, htree)
-    call wall_time(t2)
-    t_tot(6) = t_tot(6) + t2-t1
 
     ! Read instrument-specific infomation
     call tod%read_scan_inst(file, slabel, detlabels, self)
 
     ! Clean up
     call close_hdf_file(file)
-
-    call wall_time(t4)
-
-!!$    if (myid == 0) then
-!!$       write(*,*)
-!!$       write(*,*) '  IO init   = ', t_tot(1)
-!!$       write(*,*) '  IO field  = ', t_tot(2)
-!!$       write(*,*) '  IO scalar = ', t_tot(3)
-!!$       write(*,*) '  IO tod    = ', t_tot(4)
-!!$       write(*,*) '  IO comp   = ', t_tot(5)
-!!$       write(*,*) '  IO huff   = ', t_tot(6)
-!!$       write(*,*) '  IO total  = ', t4-t3
-!!$    end if
 
   end subroutine read_hdf_scan
 
@@ -1083,7 +1056,7 @@ contains
     character(len=512) :: path
     real(dp), allocatable, dimension(:,:,:) :: output
 
-    npar = 7
+    npar = 4+self%n_xi
     allocate(output(self%nscan_tot,self%ndet,npar))
 
     ! Collect all parameters
@@ -1092,12 +1065,10 @@ contains
        do i = 1, self%nscan
           k             = self%scanid(i)
           output(k,j,1) = self%scans(i)%d(j)%gain
-          output(k,j,2) = self%scans(i)%d(j)%sigma0
-          output(k,j,3) = self%scans(i)%d(j)%alpha
-          output(k,j,4) = self%scans(i)%d(j)%fknee
-          output(k,j,5) = merge(1.d0,0.d0,self%scans(i)%d(j)%accept)
-          output(k,j,6) = self%scans(i)%d(j)%chisq
-          output(k,j,7) = self%scans(i)%d(j)%baseline
+          output(k,j,2) = merge(1.d0,0.d0,self%scans(i)%d(j)%accept)
+          output(k,j,3) = self%scans(i)%d(j)%chisq
+          output(k,j,4) = self%scans(i)%d(j)%baseline
+          output(k,j,5:npar) = self%scans(i)%d(j)%xi_n
        end do
     end do
 
@@ -1112,7 +1083,8 @@ contains
     if (self%myid == 0) then
        ! Fill in defaults (closest previous)
        do j = 1, self%ndet
-          do i = 1, 4
+          do i = 1, npar
+             if (i >= 2 .and. i <= 4) cycle
              do k = 1, self%nscan_tot
                 if (output(k,j,i) == 0.d0) then
                    l = k
@@ -1150,12 +1122,10 @@ contains
        !write(*,*) 'path', trim(path)
        call create_hdf_group(chainfile, trim(adjustl(path)))
        call write_hdf(chainfile, trim(adjustl(path))//'gain',   output(:,:,1))
-       call write_hdf(chainfile, trim(adjustl(path))//'sigma0', output(:,:,2))
-       call write_hdf(chainfile, trim(adjustl(path))//'alpha',  output(:,:,3))
-       call write_hdf(chainfile, trim(adjustl(path))//'fknee',  output(:,:,4))
-       call write_hdf(chainfile, trim(adjustl(path))//'accept', output(:,:,5))
-       call write_hdf(chainfile, trim(adjustl(path))//'chisq',  output(:,:,6))
-       call write_hdf(chainfile, trim(adjustl(path))//'baseline',output(:,:,7))
+       call write_hdf(chainfile, trim(adjustl(path))//'accept', output(:,:,2))
+       call write_hdf(chainfile, trim(adjustl(path))//'chisq',  output(:,:,3))
+       call write_hdf(chainfile, trim(adjustl(path))//'baseline',output(:,:,4))
+       call write_hdf(chainfile, trim(adjustl(path))//'xi_n',   output(:,:,5:npar))
        call write_hdf(chainfile, trim(adjustl(path))//'polang', self%polang)
        call write_hdf(chainfile, trim(adjustl(path))//'gain0',  self%gain0)
        call write_hdf(chainfile, trim(adjustl(path))//'x_im',   self%x_im)
@@ -1185,16 +1155,14 @@ contains
     character(len=512) :: path
     real(dp), allocatable, dimension(:,:,:) :: output
 
-    npar = 5
+    npar = 2+self%n_xi
     allocate(output(self%nscan_tot,self%ndet,npar))
 
     call int2string(iter, itext)
     path = trim(adjustl(itext))//'/tod/'//trim(adjustl(self%freq))//'/'
     if (self%myid == 0) then
        call read_hdf(chainfile, trim(adjustl(path))//'gain',     output(:,:,1))
-       call read_hdf(chainfile, trim(adjustl(path))//'sigma0',   output(:,:,2))
-       call read_hdf(chainfile, trim(adjustl(path))//'alpha',    output(:,:,3))
-       call read_hdf(chainfile, trim(adjustl(path))//'fknee',    output(:,:,4))
+       call read_hdf(chainfile, trim(adjustl(path))//'xi_n',     output(:,:,2:4))
        call read_hdf(chainfile, trim(adjustl(path))//'accept',   output(:,:,5))
        call read_hdf(chainfile, trim(adjustl(path))//'polang',   self%polang)
        call read_hdf(chainfile, trim(adjustl(path))//'mono',     self%mono)
@@ -1225,9 +1193,10 @@ contains
           k             = self%scanid(i)
           self%scans(i)%d(j)%gain   = output(k,j,1)
           self%scans(i)%d(j)%dgain  = output(k,j,1)-self%gain0(0)-self%gain0(j)
-          self%scans(i)%d(j)%sigma0 = output(k,j,2)
-          self%scans(i)%d(j)%alpha  = output(k,j,3)
-          self%scans(i)%d(j)%fknee  = output(k,j,4)
+          !self%scans(i)%d(j)%sigma0 = output(k,j,2)
+          !self%scans(i)%d(j)%alpha  = output(k,j,3)
+          !self%scans(i)%d(j)%fknee  = output(k,j,4)          
+          self%scans(i)%d(j)%xi_n   = output(k,j,2:4)
           self%scans(i)%d(j)%accept = .true.  !output(k,j,5) == 1.d0
           if (k > 20300                    .and. (trim(self%label(j)) == '26M' .or. trim(self%label(j)) == '26S')) self%scans(i)%d(j)%accept = .false.
           if ((k > 24660 .and. k <= 25300) .and. (trim(self%label(j)) == '18M' .or. trim(self%label(j)) == '18S')) self%scans(i)%d(j)%accept = .false.
@@ -1635,14 +1604,14 @@ contains
 
     end do
 
-    if (self%scans(scan)%d(det)%sigma0 <= 0.d0) then
+    if (self%scans(scan)%d(det)%N_psd%sigma0 <= 0.d0) then
        if (present(absbp)) then
           self%scans(scan)%d(det)%chisq_prop   = 0.d0
        else
           self%scans(scan)%d(det)%chisq        = 0.d0
        end if
     else
-       chisq      = chisq      / self%scans(scan)%d(det)%sigma0**2
+       chisq      = chisq      / self%scans(scan)%d(det)%N_psd%sigma0**2
        if (present(absbp)) then
           self%scans(scan)%d(det)%chisq_prop   = chisq
        else
@@ -1653,7 +1622,7 @@ contains
     end if
     if (present(verbose)) then
       if (verbose) write(*,*) "chi2 :  ", scan, det, self%scanid(scan), &
-         & self%scans(scan)%d(det)%chisq, self%scans(scan)%d(det)%sigma0, n
+         & self%scans(scan)%d(det)%chisq, self%scans(scan)%d(det)%N_psd%sigma0, n
     end if
 !!$    if (abs(self%scans(scan)%d(det)%chisq) > 20.d0 .or. &
 !!$      & isNaN(self%scans(scan)%d(det)%chisq)) then

--- a/commander3/src/comm_tod_noise_psd_mod.f90
+++ b/commander3/src/comm_tod_noise_psd_mod.f90
@@ -1,0 +1,174 @@
+!================================================================================
+!
+! Copyright (C) 2020 Institute of Theoretical Astrophysics, University of Oslo.
+!
+! This file is part of Commander3.
+!
+! Commander3 is free software: you can redistribute it and/or modify
+! it under the terms of the GNU General Public License as published by
+! the Free Software Foundation, either version 3 of the License, or
+! (at your option) any later version.
+!
+! Commander3 is distributed in the hope that it will be useful,
+! but WITHOUT ANY WARRANTY; without even the implied warranty of
+! MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+! GNU General Public License for more details.
+!
+! You should have received a copy of the GNU General Public License
+! along with Commander3. If not, see <https://www.gnu.org/licenses/>.
+!
+!================================================================================
+module comm_tod_noise_psd_mod
+  ! 
+  !   Module for defining noise PSD models
+  !
+  !   Main Classes
+  !   ------------
+  !   comm_noise_psd
+  !       Class for basic 1/f noise model
+  !   comm_noise_psd_2oof
+  !       Class for two-component 1/f noise model
+  use comm_utils
+  implicit none
+
+  private
+  public comm_noise_psd, comm_noise_psd_2oof
+
+  type :: comm_noise_psd
+     ! 
+     ! Class definition for basic 1/f noise PSD model
+     !
+     real(sp) :: sigma0,     alpha,     fknee                 ! Main dynamic/sampling parameters
+     real(sp) :: sigma0_def, alpha_def, fknee_def             ! Default parameters/priors
+     real(dp), allocatable, dimension(:)    :: log_n_psd      ! Noise power spectrum density; in uncalibrated units
+     real(dp), allocatable, dimension(:)    :: log_n_psd2     ! Second derivative (for spline)
+     real(dp), allocatable, dimension(:)    :: log_nu         ! Noise power spectrum bins; in Hz
+   contains
+     procedure :: eval => eval_noise_psd
+  end type comm_noise_psd
+
+  type, extends(comm_noise_psd) :: comm_noise_psd_2oof
+     ! 
+     ! Class definition for 2-component 1/f noise PSD model
+     !
+     real(sp) :: alpha2,     fknee2
+     real(sp) :: alpha2_def, fknee2_def
+   contains
+     procedure :: eval => eval_noise_psd_2oof
+  end type comm_noise_psd_2oof
+
+  interface comm_noise_psd
+     procedure constructor_oof
+  end interface comm_noise_psd
+
+  interface comm_noise_psd_2oof
+     procedure constructor_2oof
+  end interface comm_noise_psd_2oof
+
+contains
+
+  function constructor_oof(xi_n, xi_n_def)
+    ! 
+    ! Constructor for basic 1/f noise PSD object, where
+    !     
+    !     P(nu) = sigma0^2 * (1 + (nu/fknee)^alpha)
+    ! 
+    ! Arguments
+    ! --------- 
+    ! xi_n:    sp (array)
+    !          3-element array containing {sigma0, alpha, fknee}, where
+    !          [sigma0] = du/volts/tod unit, [alpha] = 1, and [fknee] = Hz
+    ! xi_n_def: sp (array)
+    !          3-element array containing default parameters/prior
+    ! 
+    implicit none
+    real(sp),              dimension(:), intent(in)      :: xi_n
+    real(sp),              dimension(:), intent(in)      :: xi_n_def
+    class(comm_noise_psd), pointer                       :: constructor_oof
+
+    allocate(constructor_oof)
+    constructor_oof%sigma0     = xi_n(1)
+    constructor_oof%alpha      = xi_n(2)
+    constructor_oof%fknee      = xi_n(3)
+    constructor_oof%sigma0_def = xi_n_def(1)
+    constructor_oof%alpha_def  = xi_n_def(2)
+    constructor_oof%fknee_def  = xi_n_def(3)
+
+  end function constructor_oof
+
+  function eval_noise_psd(self, nu)
+    ! 
+    ! Evaluation routine for basic 1/f noise PSD object
+    ! 
+    ! Arguments
+    ! ---------
+    ! self:    derived type (comm_noise_psd)
+    !          Basic noise PSD object
+    ! nu:      sp (scalar)
+    !          Frequency (in Hz) at which to evaluate PSD
+    ! 
+    implicit none
+    class(comm_noise_psd),               intent(inout)   :: self
+    real(sp),                            intent(in)      :: nu
+    real(sp)                                             :: eval_noise_psd
+
+    eval_noise_psd = self%sigma0**2 * (1. + (nu/self%fknee)**self%alpha)
+
+  end function eval_noise_psd
+
+
+
+  function constructor_2oof(xi_n, xi_n_def)
+    ! 
+    ! Constructor for two-component 1/f noise PSD object, where
+    !     
+    !     P(nu) = sigma0^2 * (1 + (nu/fknee)^alpha + (nu/fknee2)^alpha2)
+    ! 
+    ! Arguments
+    ! ---------
+    ! xi_n:    sp (array)
+    !          5-element array containing {sigma0, alpha, fknee, alpha2, fknee2}, where
+    !          [sigma0] = du/volts/tod unit, [alpha,alpha2] = 1, and [fknee,fknee2] = Hz
+    ! xi_n_def: sp (array)
+    !          5-element array containing default parameters/prior values
+    ! 
+    implicit none
+    real(sp),                   dimension(:), intent(in)      :: xi_n
+    real(sp),                   dimension(:), intent(in)      :: xi_n_def
+    class(comm_noise_psd_2oof), pointer                       :: constructor_2oof
+
+    allocate(constructor_2oof)
+    constructor_2oof%sigma0     = xi_n(1)
+    constructor_2oof%alpha      = xi_n(2)
+    constructor_2oof%fknee      = xi_n(3)
+    constructor_2oof%alpha2     = xi_n(4)
+    constructor_2oof%fknee2     = xi_n(5)
+    constructor_2oof%sigma0_def = xi_n_def(1)
+    constructor_2oof%alpha_def  = xi_n_def(2)
+    constructor_2oof%fknee_def  = xi_n_def(3)
+    constructor_2oof%alpha2_def = xi_n_def(4)
+    constructor_2oof%fknee2_def = xi_n_def(5)
+
+  end function constructor_2oof
+  
+  function eval_noise_psd_2oof(self, nu)
+    ! 
+    ! Evaluation routine for 2-component 1/f noise PSD object
+    ! 
+    ! Arguments
+    ! ---------
+    ! self:    derived type (comm_noise_psd)
+    !          Basic noise PSD object
+    ! nu:      sp (scalar)
+    !          Frequency (in Hz) at which to evaluate PSD
+    ! 
+    implicit none
+    class(comm_noise_psd_2oof),          intent(inout)   :: self
+    real(sp),                            intent(in)      :: nu
+    real(sp)                                             :: eval_noise_psd_2oof
+
+    eval_noise_psd_2oof = self%sigma0**2 * (1. + (nu/self%fknee)**self%alpha + (nu/self%fknee2)**self%alpha2)
+
+  end function eval_noise_psd_2oof
+
+end module comm_tod_noise_psd_mod


### PR DESCRIPTION
This commit introduces a new module for noise PSD modelling. The most basic class is called comm_noise_psd,  and corresponds to a standard 1/f noise model. This class can then be extended to allow more general models, and one 2-component 1/f model is already implemented. 

Ps! I'm not going to comment all routines affected by this pull request, as it's a *lot* of them...

PPs! This commit only establishes the infrastructure, but don't use it yet. This should now work exactly as before, with the only difference that the noise parameters are packaged within a class.