### PR TITLE
added local sampler output parameter (for control of number of output maps)

### DIFF
--- a/commander3/parameter_files/defaults/LFI_tod.defaults
+++ b/commander3/parameter_files/defaults/LFI_tod.defaults
@@ -102,6 +102,7 @@ ALMSAMP_PRIORSAMP_FROZEN_REGIONS       = .true.
 
 #local sampler settings
 LOCALSAMP_BURN_IN                      = 2    # of gibbs iterations with steplength adjustment
+LOCALSAMP_OUTPUT_MAPS                  = .false. # {.true., .false.} output extra maps from local sampler
 
 ##############################################################
 ##              Conventions and global parameters             #

--- a/commander3/src/comm_diffuse_comp_mod.f90
+++ b/commander3/src/comm_diffuse_comp_mod.f90
@@ -157,6 +157,27 @@ module comm_diffuse_comp_mod
 contains
 
   subroutine initDiffuse(self, cpar, id, id_abs)
+    !
+    ! Routine that initializes a diffuse type component. 
+    !
+    ! Arguments:
+    ! self: comm_diffuse_comp 
+    !       Diffuse type component
+    !
+    ! cpar: Commander parameter type
+    !       Incudes all information from the parameter file
+    !
+    ! id: integer
+    !       Integer ID of the diffuse component with respect to the activ components
+    !
+    ! id_abs: integer
+    !       Integer ID of the diffuse component with respect to all components defined in the parameter file
+    !       (and also the id in the 'cpar' parameter)
+    !
+    ! Returns:
+    !       The diffuse component parameter is returned (self).
+    !       Any other changes are done internally
+    !
     implicit none
     class(comm_diffuse_comp)            :: self
     type(comm_params),       intent(in) :: cpar
@@ -2413,6 +2434,33 @@ contains
   
   ! Dump current sample to HEALPix FITS file
   subroutine dumpDiffuseToFITS(self, iter, chainfile, output_hdf, postfix, dir)
+    !
+    ! Routine that writes a diffuce component to FITS (and HDF) files. 
+    !
+    ! Arguments:
+    ! self: comm_diffuse_comp 
+    !       Diffuse type component
+    !
+    ! iter: integer
+    !       Sample number in the Gibb's chain.
+    !
+    ! chainfile: hdf_file
+    !       HDF file to write the component to
+    !
+    ! output_hdf: logical
+    !       Logical parameter to tell whether or not to write the component to the specified HDF file
+    !
+    ! postfix: string
+    !       A string label to be added to the end of FITS-files.
+    !       (default format: cXXXX_kYYYYYY; XXXX = chain number, YYYYYY = sample number)
+    !
+    ! dir: string
+    !       Output directory to which output is written
+    !
+    ! Returns:
+    !       The diffuse component parameter is returned (self).
+    !       Any other changes are done internally
+    !
     implicit none
     class(comm_diffuse_comp),                intent(inout)        :: self
     integer(i4b),                            intent(in)           :: iter

--- a/commander3/src/comm_diffuse_comp_mod.f90
+++ b/commander3/src/comm_diffuse_comp_mod.f90
@@ -45,6 +45,7 @@ module comm_diffuse_comp_mod
      character(len=512) :: cltype
      integer(i4b)       :: nside, nx, x0, ndet
      logical(lgt)       :: pol, output_mixmat, output_EB, apply_jeffreys, almsamp_pixreg, priorsamp_local
+     logical(lgt)       :: output_localsamp_maps
      integer(i4b)       :: lmin_amp, lmax_amp, lmax_ind, lmax_prior, lpiv, l_apod, lmax_pre_lowl
      integer(i4b)       :: lmax_def, nside_def, ndef, nalm_tot, sample_first_niter
 
@@ -193,6 +194,7 @@ contains
     self%latmask       = cpar%cs_latmask(id_abs)
     self%apply_jeffreys = .false.
     self%sample_first_niter = cpar%cs_local_burn_in
+    self%output_localsamp_maps = cpar%cs_output_localsamp_maps
 
     only_pol           = cpar%only_pol
     output_cg_eigenvals = cpar%output_cg_eigenvals
@@ -2610,7 +2612,7 @@ contains
           end if
           
           !write proposal length and number of proposals maps if local sampling was used
-          if (any(self%lmax_ind_pol(:min(self%nmaps,self%poltype(i)),i) < 0 .and. &
+          if (self%output_localsamp_maps .and. any(self%lmax_ind_pol(:min(self%nmaps,self%poltype(i)),i) < 0 .and. &
                & self%pol_pixreg_type(:min(self%nmaps,self%poltype(i)),i) > 0)) then
              filename = trim(self%label) // '_' // trim(self%indlabel(i)) // &
                   & '_proplen_'  // trim(postfix) // '.fits'
@@ -2623,7 +2625,7 @@ contains
           end if
 
           !if pixelregions, create map without smoothed thetas (for input in new runs)
-          if (any(self%pol_pixreg_type(1:min(self%nmaps,self%poltype(i)),i) > 0)) then
+          if (self%output_localsamp_maps .and. any(self%pol_pixreg_type(1:min(self%nmaps,self%poltype(i)),i) > 0)) then
              
              info => comm_mapinfo(self%theta(i)%p%info%comm, self%theta(i)%p%info%nside, &
                   & self%theta(i)%p%info%lmax, self%theta(i)%p%info%nmaps, self%theta(i)%p%info%pol)

--- a/commander3/src/comm_nonlin_mod.f90
+++ b/commander3/src/comm_nonlin_mod.f90
@@ -90,6 +90,28 @@ contains
 !!$  end subroutine sample_mono_dipole_with_mask
 
   subroutine sample_nonlin_params(cpar, iter, handle, handle_noise)
+    !
+    ! Routine that loops through all components and samples the spectral parameters that are defined with
+    ! non-zero RMS values
+    !
+    ! Arguments:
+    ! cpar: Commander parameter type
+    !       Incudes all information from the parameter file
+    !
+    ! iter: integer
+    !       Gibb's sample counter
+    !
+    ! handle: planck_rng type
+    !       a parameter for the RNG to produce random numbers
+    !
+    ! handle_noise: planck_rng type
+    !       a parameter for the RNG to produce random numbers
+    !
+    ! Returns:
+    !       No explicit parameter is returned.
+    !       The RNG handles are updated as they are used and returned from the routine
+    !       All other changes are done internally
+    !
     implicit none
     type(comm_params),  intent(in)    :: cpar
     integer(i4b),       intent(in)    :: iter
@@ -873,6 +895,33 @@ contains
   end subroutine sample_specind_alm
 
   subroutine sample_specind_local(cpar, iter, handle, comp_id, par_id)
+    !
+    ! Routine that sets up the sampling using the local sampling routine  for the spectral parameter given by
+    ! par_id for the component given by the comp_id parameter. 
+    ! Then it calls on the specific sampling routine and finally updates the components spectral parameter map
+    ! 
+    !
+    ! Arguments:
+    ! cpar: Commander parameter type
+    !       Incudes all information from the parameter file
+    !
+    ! iter: integer
+    !       Gibb's sample counter
+    !
+    ! handle: planck_rng type
+    !       a parameter for the RNG to produce random numbers
+    !
+    ! comp_id: integer
+    !       integer ID for the specific component to be sampled (in the list of the active components)
+    !
+    ! par_id: integer
+    !       integer ID for the specific spectral parameter to be sampled in the component given by 'comp_id'
+    !
+    ! Returns:
+    !       No explicit parameter is returned.
+    !       The RNG handle is updated as it is used and returned from the routine.
+    !       All other changes are done internally.
+    !
     implicit none
     type(comm_params),  intent(in)    :: cpar
     integer(i4b),       intent(in)    :: iter
@@ -1252,6 +1301,33 @@ contains
   !Here comes all subroutines for sampling diffuse components locally
   ! Sample spectral parameters
   subroutine sampleDiffuseSpecInd_nonlin(cpar, handle, comp_id, par_id, iter)
+    !
+    ! Overarching routine that sets up the sampling of diffuse type component spectral parameters
+    ! 
+    ! Calls on the specific sampling routine and finally updates the component's spectral parameter map
+    ! 
+    !
+    ! Arguments:
+    ! cpar: Commander parameter type
+    !       Incudes all information from the parameter file
+    !
+    ! iter: integer
+    !       Gibb's sample counter
+    !
+    ! handle: planck_rng type
+    !       a parameter for the RNG to produce random numbers
+    !
+    ! comp_id: integer
+    !       integer ID for the specific component to be sampled (in the list of the active components)
+    !
+    ! par_id: integer
+    !       integer ID for the specific spectral parameter to be sampled in the component given by 'comp_id'
+    !
+    ! Returns:
+    !       No explicit parameter is returned.
+    !       The RNG handle is updated as they are used and returned from the routine
+    !       All other changes are done internally
+    !
     implicit none
     type(comm_params),                       intent(in)           :: cpar
     type(planck_rng),                        intent(inout)        :: handle
@@ -2158,6 +2234,40 @@ contains
 
 
   subroutine sampleDiffuseSpecIndPixReg_nonlin(cpar, buffer_lnL, handle, comp_id, par_id, p, iter)
+    !
+    ! Routine that samples diffuse type component spectral parameters in pixel regions
+    ! 
+    ! Arguments:
+    ! cpar: Commander parameter type
+    !       Incudes all information from the parameter file
+    !
+    ! iter: integer
+    !       Gibb's sample counter
+    !
+    ! handle: planck_rng type
+    !       A parameter for the RNG to produce random numbers
+    !
+    ! comp_id: integer
+    !       Integer ID for the specific component to be sampled (in the list of the active components)
+    !
+    ! par_id: integer
+    !       Integer ID for the specific spectral parameter to be sampled in the component given by 'comp_id'
+    !
+    ! buffer_lnL: double precision array
+    !       An array copy of the current spectral parameter map, truncated by the absolute parameter limits.
+    !       Array with dimension (0:npix-1,nmaps), where npix is the number of pixels given by the components 
+    !       resolution parameter (Nside, see HEALPix), and nmaps is the number of polarizations (1 if only Temperature;
+    !       3 if polarization is included, TQU)
+    !
+    ! p: integer
+    !       Index counter for the polarization type that is to be sampled. Sets what map polarization(s) to be sampled.
+    !
+    ! Returns:
+    !       No explicit parameter is returned, except for the sampled spectral parameter through the 
+    !       'buffer_lnL' parameter.
+    !       The RNG handle is updated as it is used and returned from the routine.
+    !       All other changes are done internally.
+    !
     implicit none
     type(comm_params),                       intent(in)           :: cpar
     real(dp),               dimension(0:,:), intent(inout)        :: buffer_lnL

--- a/commander3/src/comm_nonlin_mod.f90
+++ b/commander3/src/comm_nonlin_mod.f90
@@ -2979,8 +2979,8 @@ contains
        write(*,*) ''
     end if
 
-    !debug
-    if (allocated(lr_chisq)) then
+    !debug output
+    if (.false. .and. cpar%cs_output_localsamp_maps .and. allocated(lr_chisq)) then
        call int2string(cpar%mychain, ctext)
        call int2string(iter,         itext)
 
@@ -3017,8 +3017,8 @@ contains
     call int2string(cpar%mychain, ctext)
     postfix = 'c'//ctext//'_k'//itext//'_p'//pind_txt
 
-    !print MC theta to file
-    if (myid_pix==0) then
+    !print MC theta to file, (partially debug)
+    if (.false. .and. cpar%cs_output_localsamp_maps .and. myid_pix==0) then
        unit = getlun()
        filename=trim(cpar%outdir)//'/'//trim(c_lnl%label)//'_'//trim(c_lnL%indlabel(id))//&
             & '_theta_MC_'//trim(postfix)//'.dat'
@@ -3035,7 +3035,8 @@ contains
        deallocate(theta_MC_arr)
     end if
 
-    if (.true.) then
+    ! debug output
+    if (cpar%cs_output_localsamp_maps .and. .false.) then
        do i = 1,band_count
           filename=trim(cpar%outdir)//'/'//'reduced_data_band_'//trim(data(band_i(i))%label)//'_'// &
                & trim(c_lnl%label)//'_'//trim(c_lnL%indlabel(id))//'_'//trim(postfix)//'.fits'

--- a/commander3/src/comm_param_mod.f90
+++ b/commander3/src/comm_param_mod.f90
@@ -151,6 +151,7 @@ module comm_param_mod
      character(len=512) :: cs_inst_parfile
      character(len=512) :: cs_init_inst_hdf
      integer(i4b)       :: cs_ncomp, cs_ncomp_tot, cs_local_burn_in
+     logical(lgt)       :: cs_output_localsamp_maps
      real(dp)           :: cmb_dipole_prior(3)
      character(len=512) :: cmb_dipole_prior_mask
      logical(lgt),       allocatable, dimension(:)     :: cs_include
@@ -651,6 +652,7 @@ contains
        call get_parameter_hashtable(htbl, 'CG_SAMPLING_GROUP_MAXITER'//itext, par_int=cpar%cg_samp_group_maxiter(i))
     end do
     call get_parameter_hashtable(htbl, 'LOCALSAMP_BURN_IN', par_int=cpar%cs_local_burn_in)
+    call get_parameter_hashtable(htbl, 'LOCALSAMP_OUTPUT_MAPS', par_lgt=cpar%cs_output_localsamp_maps)
 
 
     n = cpar%cs_ncomp_tot


### PR DESCRIPTION
Just added a parameter to limit (optionally) then number of outputs of the local sampler (upon request).

The added parameter is LOCALSAMP_OUTPUT_MAPS (default set to .false.) which controls whether or not to output the Nprop, proposal length and spectral index per pixel region (no smoothing) i HEALPix maps. These maps are only needed if one wants to initialize the local sampler from tuned in parameters (e.g. value per pixel region) and one cannot initialize from chain.

I know per guideline rules I would be required to comment all the routines and functions I've edited, but I absolutely do not have time to do this at this moment. At one point I will be forced to clean up the sampling routines for local sampling, as this has many unused routines, as well as adding support for non-diagonal noise matrix chisq evaluation for the local sampler.

This small ("bug") fix will limit the number of files in the output folder for many of the users.