### PR TITLE
Spider harald

### DIFF
--- a/commander3/src/Makefile
+++ b/commander3/src/Makefile
@@ -154,7 +154,7 @@ comm_conviqt_mod.o          : sharp.o comm_map_mod.o comm_utils.o comm_shared_ar
 comm_cr_mod.o               : comm_comp_mod.o comm_data_mod.o comm_param_mod.o comm_diffuse_comp_mod.o comm_ptsrc_comp_mod.o comm_template_comp_mod.o comm_cr_utils.o comm_cr_precond_mod.o math_tools.o comm_output_mod.o
 comm_cr_precond_mod.o       : comm_utils.o
 comm_cr_utils.o             : comm_utils.o
-comm_data_mod.o             : comm_param_mod.o comm_bp_mod.o comm_noise_mod.o comm_beam_mod.o comm_map_mod.o comm_tod_mod.o comm_tod_lfi_mod.o comm_tod_spider_mod.o comm_tod_wmap_mod.o comm_tod_lb_mod.o comm_tod_quiet_mod.o locate_mod.o
+comm_data_mod.o             : comm_param_mod.o comm_bp_mod.o comm_noise_mod.o comm_beam_mod.o comm_map_mod.o comm_tod_mod.o comm_tod_lfi_mod.o comm_tod_spider_mod.o comm_tod_wmap_mod.o comm_tod_lb_mod.o comm_tod_quiet_mod.o locate_mod.o comm_bp_utils.o
 comm_diffuse_comp_mod.o     : comm_param_mod.o comm_comp_mod.o comm_map_mod.o comm_data_mod.o comm_f_int_mod.o comm_cl_mod.o math_tools.o comm_cr_utils.o comm_cr_precond_mod.o comm_hdf_mod.o invsamp_mod.o powell_mod.o comm_beam_mod.o
 comm_diffuse_comp_smod.o    : comm_diffuse_comp_mod.o
 comm_fft_mod.o              : comm_utils.o comm_param_mod.o locate_mod.o

--- a/commander3/src/comm_bp_mod.f90
+++ b/commander3/src/comm_bp_mod.f90
@@ -107,7 +107,7 @@ contains
     character(len=512) :: dir, label
     character(len=16)  :: dets(1500)
     real(dp), allocatable, dimension(:) :: nu0, tau0
-
+    
     label = cpar%ds_label(id_abs)
     
     ! General parameters
@@ -151,6 +151,7 @@ contains
     else
        constructor%unit_scale = 1.d0
     end if
+
 
     ! Initialize raw bandpass
     if (trim(constructor%type) == 'delta') then
@@ -208,6 +209,7 @@ contains
 
     ! WARNING! Should be replaced with proper integral. See planck2013 HFI spectral response eq. 2
     constructor%nu_eff = sum(constructor%tau*constructor%nu)/sum(constructor%tau)
+    
 
   end function constructor
   
@@ -458,5 +460,6 @@ contains
     lineAmp_RJ = lineAmp_RJ * 1.d9 ! Convert to uK_ant / (K_ant km/s)
 
   end function lineAmp_RJ
+
 
 end module comm_bp_mod

--- a/commander3/src/comm_data_mod.f90
+++ b/commander3/src/comm_data_mod.f90
@@ -31,6 +31,7 @@ module comm_data_mod
   use comm_tod_LB_mod
   use comm_tod_QUIET_mod
   use locate_mod
+  use comm_bp_utils
   implicit none
 
   type comm_data_set
@@ -82,12 +83,15 @@ contains
     type(comm_params), intent(in)    :: cpar
     type(planck_rng),  intent(inout) :: handle
 
-    integer(i4b)       :: i, j, n, nmaps, numband_tot, ierr
+    integer(i4b)       :: i, j, k, n, nmaps, numband_tot, ierr
     character(len=512) :: dir, mapfile
     class(comm_N), pointer  :: tmp => null()
     class(comm_mapinfo), pointer :: info_smooth => null(), info_postproc => null()
     real(dp), allocatable, dimension(:)   :: nu
     real(dp), allocatable, dimension(:,:) :: regnoise, mask_misspix
+
+    real(dp), allocatable, dimension(:) :: nu_dummy, tau_dummy
+    integer(i4b)                        :: n_dummy
 
     ! Read all data sets
     numband = count(cpar%ds_active)
@@ -235,11 +239,29 @@ contains
        data(n)%pol_only = data(n)%N%pol_only
        call update_status(status, "data_N")
 
-       ! Initialize bandpass structures; 0 is full freq, i is detector
+       ! Initialize bandpass structures; 0 is full freq, i is detector       
        allocate(data(n)%bp(0:data(n)%ndet))
-
        do j = 1, data(n)%ndet
-          data(n)%bp(j)%p => comm_bp(cpar, n, i, detlabel=data(n)%tod%label(j))
+          if (j==1) then
+            data(n)%bp(j)%p => comm_bp(cpar, n, i, detlabel=data(n)%tod%label(j))
+          else
+            ! Check if bandpass already exists in detector list
+            call read_bandpass(trim(cpar%datadir) // '/' // cpar%ds_bpfile(i), &
+                              & data(n)%tod%label(j), &
+                              & 0.d0, &
+                              & n_dummy, &
+                              & nu_dummy, &
+                              & tau_dummy)
+            do k=1, j
+               if (all(tau_dummy==data(n)%bp(k)%p%tau0)) then
+                  data(n)%bp(j)%p => data(n)%bp(k)%p ! If bp exists, point to existing object
+                  exit
+               else if (k==j) then
+                  data(n)%bp(j)%p => comm_bp(cpar, n, i, detlabel=data(n)%tod%label(j))
+               end if
+            end do
+            deallocate(nu_dummy, tau_dummy)
+          end if
        end do
 
        if (trim(cpar%ds_tod_type(i)) == 'none') then

--- a/commander3/src/comm_diffuse_comp_smod.f90
+++ b/commander3/src/comm_diffuse_comp_smod.f90
@@ -218,8 +218,21 @@ contains
             & self%lmax_ind, data(i)%info%nmaps, data(i)%info%pol)
 !       write(*,*) i, 'ndet = ', data(i)%ndet, shape(self%F), info%nside
        do j = 0, data(i)%ndet
-          self%F(i,j)%p    => comm_map(info)
-          self%F_null(i,j) =  .false.
+          if (j<=1) then
+            self%F(i,j)%p    => comm_map(info)
+            self%F_null(i,j) =  .false.
+          else
+            do k=1, j
+               if (all(data(i)%bp(k)%p%tau0==data(i)%bp(j)%p%tau0)) then
+                  self%F(i,j)%p => self%F(i,k)%p
+                  self%F_null(i,j) =  .false.
+                  exit
+               else if (k==j) then
+                  self%F(i,j)%p    => comm_map(info)
+                  self%F_null(i,j) =  .false.
+               end if
+            end do
+          end if
        end do
     end do
     call update_status(status, "init_postmix")

--- a/commander3/src/comm_tod_mod.f90
+++ b/commander3/src/comm_tod_mod.f90
@@ -878,9 +878,9 @@ contains
        self%d(i)%gain       = self%d(i)%gain_def
        self%d(i)%accept     = .true.
 
-       !if (trim(tod%noise_psd_model) == 'oof') then
-       !   self%d(i)%N_psd => comm_noise_psd(xi_n, tod%xi_n_P_rms, tod%xi_n_P_uni, tod%xi_n_nu_fit)
-       if (trim(tod%noise_psd_model) == '2oof') then
+       if (trim(tod%noise_psd_model) == 'oof') then
+         self%d(i)%N_psd => comm_noise_psd(self%d(i)%xi_n, tod%xi_n_P_rms, tod%xi_n_P_uni, tod%xi_n_nu_fit)
+       else if (trim(tod%noise_psd_model) == '2oof') then
           self%d(i)%xi_n(4) =  1e-4  ! fknee2 (Hz); arbitrary value
           self%d(i)%xi_n(5) = -1.000 ! alpha2; arbitrary value
        !   self%d(i)%N_psd => comm_noise_psd_2oof(xi_n, tod%xi_n_P_rms, tod%xi_n_P_uni, tod%xi_n_nu_fit)
@@ -1380,7 +1380,8 @@ contains
           output(k,j,2)      = merge(1.d0,0.d0,self%scans(i)%d(j)%accept)
           output(k,j,3)      = self%scans(i)%d(j)%chisq
           output(k,j,4)      = self%scans(i)%d(j)%baseline
-          output(k,j,5:npar) = self%scans(i)%d(j)%N_psd%xi_n
+         !  output(k,j,5:npar) = self%scans(i)%d(j)%N_psd%xi_n
+          output(k,j,5:npar) = self%scans(i)%d(j)%xi_n
        end do
     end do
 


### PR DESCRIPTION
Edited bandpass initialization in `comm_data_mod.f90 (244-265)`:
When looping through detectors, and the bandpass that is read from the file already exists, point to the already existing object instead of instantiating a new one.

Edited mixing matrix allocation in `comm_diffuse_comp_smod.f90 (216-237)`:
Equivalent to above, when looping through detectors and the bandpass is identical to that of a previous detector, don't create a new map object, but point to an existing one instead. 