### PR TITLE
Replace `pix2vec` lookup with `ind2vec` to save memory

### DIFF
--- a/commander3/src/comm_tod_mod.f90
+++ b/commander3/src/comm_tod_mod.f90
@@ -150,7 +150,6 @@ module comm_tod_mod
      real(sp),           allocatable, dimension(:)     :: sin2psi  ! Lookup table of sin(2psi)
      real(sp),           allocatable, dimension(:)     :: cos2psi  ! Lookup table of cos(2psi)
      real(sp),           allocatable, dimension(:)     :: psi      ! Lookup table of psi
-     real(dp),           allocatable, dimension(:,:)   :: pix2vec  ! Lookup table of pix2vec
      real(dp),           allocatable, dimension(:,:)   :: L_prop_mono  ! Proposal matrix for monopole sampling
      real(dp),           allocatable, dimension(:,:)   :: v_sun    ! Sun velocities for all scans (3, nscan_tot)
      type(comm_scan),    allocatable, dimension(:)     :: scans    ! Array of all scans
@@ -171,8 +170,10 @@ module comm_tod_mod
      class(conviqt_ptr), allocatable, dimension(:)     :: slconvA, slconvB ! SL-convolved maps (ndet)
      real(dp),           allocatable, dimension(:,:)   :: bp_delta  ! Bandpass parameters (0:ndet, npar)
      real(dp),           allocatable, dimension(:,:)   :: spinaxis ! For load balancing
-     integer(i4b),       allocatable, dimension(:)     :: pix2ind, ind2pix, ind2sl
-     real(sp),           allocatable, dimension(:,:)   :: ind2ang
+     integer(i4b),       allocatable, dimension(:)     :: pix2ind ! Array mapping all npix pixels to the uniquely observed pixels in the tod object for saving memory
+     integer(i4b),       allocatable, dimension(:)     :: ind2pix, ind2sl ! Lookup tables used with pix2ind 
+     real(sp),           allocatable, dimension(:,:)   :: ind2ang ! Lookup tables used with pix2ind for pixel angles
+     real(dp),           allocatable, dimension(:,:)   :: ind2vec ! Lookup tables used with pix2ind for pixel unit vectors
      character(len=128)                                :: tod_type
      integer(i4b)                                      :: nside_beam
      integer(i4b)                                      :: verbosity ! verbosity of output
@@ -463,14 +464,6 @@ contains
     integer(i4b) :: i, j, k, l, np_vec, ierr
     integer(i4b), allocatable, dimension(:) :: pix
 
-
-    ! Lastly, create a vector pointing table for fast look-up for orbital dipole
-    np_vec = 12*self%nside**2 !npix
-    allocate(self%pix2vec(3,0:np_vec-1))
-    do i = 0, np_vec-1
-       call pix2vec_ring(self%nside, i, self%pix2vec(:,i))
-    end do
-
     ! Construct observed pixel array
     allocate(self%pix2ind(0:12*self%nside**2-1))
     self%pix2ind = -1
@@ -505,12 +498,14 @@ contains
     allocate(self%ind2pix(self%nobs))
     allocate(self%ind2sl(self%nobs))
     allocate(self%ind2ang(2,self%nobs))
+    allocate(self%ind2vec(3,self%nobs))
     j = 1
     do i = 0, 12*self%nside**2-1
        if (self%pix2ind(i) == 1) then
           self%ind2pix(j) = i
           self%pix2ind(i) = j
           call pix2ang_ring(self%nside, i, theta, phi)
+          call pix2vec_ring(self%nside, i, self%ind2vec(:,j))
           call ang2pix_ring(self%nside_beam, theta, phi, self%ind2sl(j))
           self%ind2ang(:,j) = [theta,phi]
           j = j+1
@@ -1850,7 +1845,7 @@ contains
           v_ref = v_solar
          !  v_ref = self%scans(scan)%v_sun !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
           do i = 1, ntod
-             P(:,i) =  self%pix2vec(:,pix(i,j)) ! [v_x, v_y, v_z]
+             P(:,i) =  self%ind2vec(:,self%pix2ind(pix(i,j))) ! [v_x, v_y, v_z]
           end do
        end if
 
@@ -1924,7 +1919,7 @@ contains
        end do
     else
        do i = 1, ntod
-          P(:,i) =  self%pix2vec(:,pix(i,j)) ! [v_x, v_y, v_z]
+          P(:,i) =  self%ind2vec(:,self%pix2ind(pix(i,j))) ! [v_x, v_y, v_z]
        end do
     end if
 


### PR DESCRIPTION
Each `tod` object has been storing a `(3, npix)` lookup of pixel unit vectors. We can save a lot of memory by replacing this with a `(3, nobs)` lookup similar to how we do with `ind2pix` and `ind2ang`.